### PR TITLE
feat: Oura API v1.35 support + bedtime_end midnight fix (v2.8.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A modern Home Assistant custom integration for Oura Ring using the v2 API with O
 
 - **Oura Ring 5 Compatible**: Fully tested with all Oura Ring generations including the latest Oura Ring 5
 - **OAuth2 Authentication**: Secure authentication using Home Assistant's application credentials
-- **Comprehensive Data**: 68 sensors and 2 binary sensors covering Oura Ring sleep, readiness, activity, workout, session, tags, rest mode, stress, resilience, battery, cardiovascular health, and more
+- **Comprehensive Data**: 69 sensors and 2 binary sensors covering Oura Ring sleep, readiness, activity, workout, session, tags, rest mode, stress, resilience, battery, cardiovascular health, and more
 - **HA 2026 Compatible**: Modern entity naming, translation keys, entity categories, and proper state classes
 - **Historical Data Loading**: Automatically loads 3 months of historical data on first setup (configurable 1-48 months, up to 4 years)
 - **Expanded Daily Tracking**: Adds workout, mindfulness session, tag, and rest mode tracking with historical statistics support
@@ -19,12 +19,12 @@ A modern Home Assistant custom integration for Oura Ring using the v2 API with O
 - **Multi-Account Support**: Entry-scoped unique IDs allow multiple Oura accounts
 - **HACS Compatible**: Easy installation and updates via HACS
 - **Modern Architecture**: Configuration-driven design following latest Home Assistant standards
-- **Comprehensive Testing**: 105 automated tests ensuring reliability
+- **Comprehensive Testing**: 106 automated tests ensuring reliability
 - **Efficient Updates**: Uses DataUpdateCoordinator with specialized processing methods
 
 ## Available Sensors
 
-### Sleep Sensors (16)
+### Sleep Sensors (17)
 - Sleep Score
 - Total Sleep Duration
 - Deep Sleep Duration
@@ -41,6 +41,7 @@ A modern Home Assistant custom integration for Oura Ring using the v2 API with O
 - Bedtime Start (when you went to sleep)
 - Bedtime End (when you woke up)
 - Low Battery Alert
+- Sleep Analysis Reason (diagnostic: how sleep was detected — foreground app sync, background detection, or bedtime edit; Ring 5 supports background detection via API 1.35+)
 
 **Note**: Sleep Efficiency now uses the actual detailed sleep efficiency percentage from Oura sleep data rather than the contributor score.
 
@@ -98,7 +99,7 @@ A modern Home Assistant custom integration for Oura Ring using the v2 API with O
 ### Fitness Sensors (3) - *Requires Oura membership*
 - VO2 Max ⚠️
 - Cardiovascular Age ⚠️
-- Pulse Wave Velocity (arterial stiffness in m/s, API 1.34+) ⚠️
+- Pulse Wave Velocity (arterial stiffness in m/s, API 1.35+) ⚠️
 
 ### Sleep Optimization Sensors (2) - *May be unavailable for new rings*
 - Optimal Bedtime Start ⚠️
@@ -131,7 +132,7 @@ A modern Home Assistant custom integration for Oura Ring using the v2 API with O
 - Rest Mode
 - Ring Charging
 
-**Total: 68 sensors + 2 binary sensors**
+**Total: 69 sensors + 2 binary sensors**
 
 **Important Notes**:
 - Sensors marked with ⚠️ may be **unavailable** for new Oura Ring users (typically the first few weeks of usage). The Oura API does not provide data for these sensors until sufficient baseline data has been collected. This is normal behavior and they may become available over time as you continue using your ring.
@@ -936,7 +937,7 @@ This integration is built using modern Home Assistant patterns:
 - **Type Hints**: Full type hint coverage for better code quality
 - **Async**: All operations are asynchronous
 - **Error Handling**: Comprehensive error handling and clean logging
-- **Test Coverage**: 105 automated tests with comprehensive fixtures
+- **Test Coverage**: 106 automated tests with comprehensive fixtures
 
 ## Contributing
 
@@ -983,7 +984,7 @@ This project is licensed under the MIT License.
 - Original Oura Component: [nitobuendia/oura-custom-component](https://github.com/nitobuendia/oura-custom-component)
 - Oura Ring API: [Oura Cloud API Documentation](https://cloud.ouraring.com/v2/docs)
 - v2.0.0 Modernization: Comprehensive refactoring to HA 2026 standards
-- Test Infrastructure: Docker-based testing with 105 automated tests
+- Test Infrastructure: Docker-based testing with 106 automated tests
 - Development assisted by: Claude Sonnet 4.6 (Anthropic AI)
 
 ## Sponsoring

--- a/custom_components/oura/binary_sensor.py
+++ b/custom_components/oura/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, DOMAIN
+from .const import ATTRIBUTION, DOMAIN, RING_MODEL_NAMES
 from .coordinator import OuraDataUpdateCoordinator
 
 
@@ -19,7 +19,7 @@ def _oura_device_info(coordinator: OuraDataUpdateCoordinator) -> DeviceInfo:
     sw_version = None
     if coordinator.data:
         if hw_type := coordinator.data.get("ring_hardware_type"):
-            model = f"Oura Ring {hw_type.capitalize()}"
+            model = f"Oura Ring {RING_MODEL_NAMES.get(hw_type, hw_type.capitalize())}"
         sw_version = coordinator.data.get("ring_firmware_version")
     return DeviceInfo(
         identifiers={(DOMAIN, coordinator.entry.entry_id)},

--- a/custom_components/oura/const.py
+++ b/custom_components/oura/const.py
@@ -6,6 +6,16 @@ from homeassistant.const import UnitOfEnergy, UnitOfLength, UnitOfTime
 from homeassistant.helpers.entity import EntityCategory
 
 DOMAIN: Final = "oura"
+
+# Ring hardware type → model display name
+RING_MODEL_NAMES: Final = {
+    "gen1": "Gen 1",
+    "gen2": "Gen 2",
+    "gen2m": "Gen 2M",
+    "gen3": "Gen 3",
+    "gen4": "4",
+    "or5": "5",
+}
 ATTRIBUTION: Final = "Data provided by Oura Ring"
 
 # Configuration
@@ -92,6 +102,7 @@ SENSOR_TYPES: Final = {
 
     # HRV sensors (from detailed sleep endpoint)
     "average_sleep_hrv": {"name": "Average Sleep HRV", "icon": "mdi:heart-pulse", "unit": "ms", "device_class": None, "state_class": "measurement", "entity_category": None, "data_category": "sleep_detail"},
+    "sleep_analysis_reason": {"name": "Sleep Analysis Reason", "icon": "mdi:sleep", "unit": None, "device_class": "enum", "state_class": None, "entity_category": EntityCategory.DIAGNOSTIC, "options": ["foreground_sleep_analysis", "bedtime_edit", "background_sleep_analysis", "background_created_foreground_updated"], "data_category": "sleep_detail"},
 
     # Stress sensors
     "stress_high_duration": {"name": "Stress High Duration", "icon": "mdi:account-question", "unit": "min", "device_class": "duration", "state_class": "total", "entity_category": None, "data_category": "stress"},

--- a/custom_components/oura/coordinator.py
+++ b/custom_components/oura/coordinator.py
@@ -194,7 +194,10 @@ class OuraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             r for r in completed
             if (self._parse_api_day(r.get("day")) or date.min) >= max_age
         ]
-        completed.sort(key=lambda r: self._parse_api_day(r.get("day")) or date.min)
+        completed.sort(key=lambda r: (
+            self._parse_api_day(r.get("day")) or date.min,
+            r.get("total_sleep_duration") or 0,
+        ))
 
         if completed:
             # Prefer long_sleep (main overnight sleep >3h) over naps when multiple
@@ -270,6 +273,10 @@ class OuraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Low battery alert flag (always set, defaults to False)
         processed["low_battery_alert"] = latest_sleep_detail.get("low_battery_alert", False)
+
+        # Sleep analysis reason (how sleep was detected: foreground/background)
+        if reason := latest_sleep_detail.get("sleep_analysis_reason"):
+            processed["sleep_analysis_reason"] = reason
 
     def _process_readiness(self, data: dict[str, Any], processed: dict[str, Any]) -> None:
         """Process readiness data (contributors are scores 1-100)."""

--- a/custom_components/oura/manifest.json
+++ b/custom_components/oura/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/louispires/oura-v2-custom-component/issues",
   "requirements": [],
-  "version": "2.8.1"
+  "version": "2.8.2"
 }

--- a/custom_components/oura/sensor.py
+++ b/custom_components/oura/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, DOMAIN, SENSOR_TYPES
+from .const import ATTRIBUTION, DOMAIN, RING_MODEL_NAMES, SENSOR_TYPES
 from .coordinator import OuraDataUpdateCoordinator
 
 
@@ -64,7 +64,7 @@ class OuraSensor(CoordinatorEntity[OuraDataUpdateCoordinator], SensorEntity):
         sw_version = None
         if self.coordinator.data:
             if hw_type := self.coordinator.data.get("ring_hardware_type"):
-                model = f"Oura Ring {hw_type.capitalize()}"
+                model = f"Oura Ring {RING_MODEL_NAMES.get(hw_type, hw_type.capitalize())}"
             sw_version = self.coordinator.data.get("ring_firmware_version")
         return DeviceInfo(
             identifiers={(DOMAIN, self.coordinator.entry.entry_id)},

--- a/custom_components/oura/strings.json
+++ b/custom_components/oura/strings.json
@@ -83,6 +83,7 @@
       "max_heart_rate": {"name": "Maximum heart rate"},
       "heart_rate_timestamp": {"name": "Last heart rate reading"},
       "average_sleep_hrv": {"name": "Average sleep HRV"},
+      "sleep_analysis_reason": {"name": "Sleep analysis reason"},
       "lowest_sleep_heart_rate": {"name": "Lowest sleep heart rate"},
       "average_sleep_heart_rate": {"name": "Average sleep heart rate"},
       "stress_high_duration": {"name": "Stress high duration"},

--- a/custom_components/oura/translations/de.json
+++ b/custom_components/oura/translations/de.json
@@ -83,6 +83,7 @@
       "max_heart_rate": {"name": "Maximale Herzfrequenz"},
       "heart_rate_timestamp": {"name": "Letzte Herzfrequenzmessung"},
       "average_sleep_hrv": {"name": "Durchschnittliche Schlaf-HRV"},
+      "sleep_analysis_reason": {"name": "Schlafanalysegrund"},
       "lowest_sleep_heart_rate": {"name": "Niedrigste Schlafherzfrequenz"},
       "average_sleep_heart_rate": {"name": "Durchschnittliche Schlafherzfrequenz"},
       "stress_high_duration": {"name": "Hohe Stressdauer"},

--- a/custom_components/oura/translations/es.json
+++ b/custom_components/oura/translations/es.json
@@ -83,6 +83,7 @@
       "max_heart_rate": {"name": "Frecuencia cardíaca máxima"},
       "heart_rate_timestamp": {"name": "Última lectura de frecuencia cardíaca"},
       "average_sleep_hrv": {"name": "HRV promedio durante el sueño"},
+      "sleep_analysis_reason": {"name": "Motivo del análisis de sueño"},
       "lowest_sleep_heart_rate": {"name": "Frecuencia cardíaca más baja durante el sueño"},
       "average_sleep_heart_rate": {"name": "Frecuencia cardíaca promedio durante el sueño"},
       "stress_high_duration": {"name": "Duración de estrés alto"},

--- a/custom_components/oura/translations/fr.json
+++ b/custom_components/oura/translations/fr.json
@@ -83,6 +83,7 @@
       "max_heart_rate": {"name": "Fréquence cardiaque maximale"},
       "heart_rate_timestamp": {"name": "Dernière mesure de fréquence cardiaque"},
       "average_sleep_hrv": {"name": "VFC moyenne pendant le sommeil"},
+      "sleep_analysis_reason": {"name": "Raison de l'analyse du sommeil"},
       "lowest_sleep_heart_rate": {"name": "Fréquence cardiaque la plus basse pendant le sommeil"},
       "average_sleep_heart_rate": {"name": "Fréquence cardiaque moyenne pendant le sommeil"},
       "stress_high_duration": {"name": "Durée de stress élevé"},

--- a/docs/Oura API/openapi-1.35.json
+++ b/docs/Oura API/openapi-1.35.json
@@ -1,0 +1,11657 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Oura API Documentation",
+    "description": "# Overview \nThe Oura API allows Oura users and partner applications to improve their user experience with Oura data.\nThis document describes the Oura API Version 2 (V2), which is the only available integration point for Oura data. The previous V1 API has been sunset.\n# Getting Started \n## What is an API?\nAn API (Application Programming Interface) allows different software applications to communicate with each other. The Oura API enables you to access your Oura Ring data programmatically.\n## Quick Start Guide\n1. Register an [API Application](https://cloud.ouraring.com/oauth/applications) and implement OAuth2\n2. **Make Your First API Call**:\n   ```\n   curl -X GET https://api.ouraring.com/v2/usercollection/personal_info \\\n   -H \"Authorization: Bearer YOUR_TOKEN_HERE\"\n   ```\n3. **Explore Data Types**:\n   - Browse the available endpoints in this documentation to discover what data you can access\n   - Each endpoint includes example requests and responses\n4. **Set Up Webhooks (Strongly Recommended)**:\n   - Webhooks are the preferred way to consume Oura data\n   - We have not had customers hit rate limits with webhooks properly implemented\n   - Make a single request for historical data when a user first connects, then use webhooks for ongoing updates\n   - Webhook notifications come approximately 30 seconds after data syncs from the mobile app\n   - [Set up webhooks](#tag/Webhook-Subscription-Routes) to receive notifications when data changes\n## Common Questions\n- **Data Delay**: Different data types sync at different times - sleep data requires users to open the Oura app, while daily activity and stress may sync in the background\n# Data Access\nIn order to access data, a registered [API Application](https://cloud.ouraring.com/oauth/applications) is required.\n API Applications are limited to **10** users before requiring approval from Oura. There is no limit once an application is approved.\n Additionally, Oura users **must provide consent** to share each data type an API Application has access to.\nAll data access requests through the Oura API require [Authentication](https://cloud.ouraring.com/docs/authentication).\nAdditionally, we recommend that Oura users keep their mobile app updated to support API access for the latest data types.\n# Authentication\nThe Oura Cloud API supports authentication through the industry-standard OAuth2 protocol. For more information, see our [Authentication instructions](https://cloud.ouraring.com/docs/authentication).\nAccess tokens must be included in the request header as follows:\n```http\nGET /v2/usercollection/personal_info HTTP/1.1\nHost: api.ouraring.com\nAuthorization: Bearer <token>\n```\nPlease note that personal access tokens were deprecated in December 2025 and are no longer available for use.\n# Oura HTTP Response Codes\n| Response Code                        | Description |\n| ------------------------------------ | - |\n| 200 OK                               | Successful Response         |\n| 400 Query Parameter Validation Error | The request contains query parameters that are invalid or incorrectly formatted. |\n| 401 Unauthorized                     | Invalid or expired authentication token. |\n| 403 Forbidden                        | The requested resource requires additional permissions or the user's Oura subscription has expired. |\n| 429 Too Many Requests                | Rate limit exceeded. See response headers for retry guidance. |\n\n## Rate Limits\nThe API enforces rate limits at two layers to ensure fair access across all applications:\n- a per-access-token limit, which throttles single-token floods, and\n- a per-application limit, which caps the aggregate traffic across all of an application's end-user tokens so one fan-out app can't dominate shared capacity.\n\nA request that trips either layer receives a `429 Too Many Requests`. The `X-RateLimit-Tier` response header identifies which layer fired.\n\nIf your application regularly approaches rate limits, [webhooks](#tag/Webhook-Subscription-Routes) are strongly recommended — most applications that implement webhooks correctly do not encounter rate limit issues.\n\n[Contact us](mailto:api-support@ouraring.com) if you expect your usage to require higher limits.\n\n## Rate Limit Response Headers\nWhen a `429 Too Many Requests` response is returned, five headers are included to guide retries. Prefer these over fixed-interval backoff:\n- **`Retry-After`** — integer seconds to wait before retrying. RFC 7231-compliant; safe to feed directly into your client's backoff logic.\n- **`X-RateLimit-Limit`** — the request ceiling for the current window.\n- **`X-RateLimit-Window`** — the rolling window length in seconds that the ceiling applies to.\n- **`X-RateLimit-Reset`** — Unix epoch (seconds) at which the window resets and quota is fully restored.\n- **`X-RateLimit-Tier`** — identifies which limit was exceeded, useful when contacting support.\n",
+    "termsOfService": "https://cloud.ouraring.com/legal/api-agreement",
+    "version": "2.0",
+    "x-logo": {
+      "url": "/v2/static/img/Oura_Logo-Developer_RBG_Black.svg"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.None.com",
+      "description": "Oura API"
+    }
+  ],
+  "paths": {
+    "/v2/sandbox/usercollection/daily_activity": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Daily Activity Documents",
+        "operationId": "Sandbox___Multiple_daily_activity_Documents_v2_sandbox_usercollection_daily_activity_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailyActivity_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Daily Activity Documents V2 Sandbox Usercollection Daily Activity Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_activity?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_activity' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_activity?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_activity?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_activity/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Daily Activity Document",
+        "operationId": "Sandbox___Single_daily_activity_Document_v2_sandbox_usercollection_daily_activity__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailyActivity"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_activity/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_activity/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_activity/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_activity/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_cardiovascular_age": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Daily Cardiovascular Age Documents",
+        "operationId": "Sandbox___Multiple_daily_cardiovascular_age_Documents_v2_sandbox_usercollection_daily_cardiovascular_age_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailyCardiovascularAge_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Daily Cardiovascular Age Documents V2 Sandbox Usercollection Daily Cardiovascular Age Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_cardiovascular_age?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_cardiovascular_age' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_cardiovascular_age?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_cardiovascular_age?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_cardiovascular_age/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Daily Cardiovascular Age Document",
+        "operationId": "Sandbox___Single_daily_cardiovascular_age_Document_v2_sandbox_usercollection_daily_cardiovascular_age__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailyCardiovascularAge"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_cardiovascular_age/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_cardiovascular_age/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_cardiovascular_age/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_cardiovascular_age/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_readiness": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Daily Readiness Documents",
+        "operationId": "Sandbox___Multiple_daily_readiness_Documents_v2_sandbox_usercollection_daily_readiness_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailyReadiness_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Daily Readiness Documents V2 Sandbox Usercollection Daily Readiness Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_readiness?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_readiness' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_readiness?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_readiness?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_readiness/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Daily Readiness Document",
+        "operationId": "Sandbox___Single_daily_readiness_Document_v2_sandbox_usercollection_daily_readiness__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailyReadiness"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_readiness/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_readiness/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_readiness/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_readiness/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_resilience": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Daily Resilience Documents",
+        "operationId": "Sandbox___Multiple_daily_resilience_Documents_v2_sandbox_usercollection_daily_resilience_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_DailyResilienceModel_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Daily Resilience Documents V2 Sandbox Usercollection Daily Resilience Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_resilience?start_date=2021-11-01&end_date=2021-12-01' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_resilience' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_resilience?start_date=2021-11-01&end_date=2021-12-01', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_resilience?start_date=2021-11-01&end_date=2021-12-01\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_resilience/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Daily Resilience Document",
+        "operationId": "Sandbox___Single_daily_resilience_Document_v2_sandbox_usercollection_daily_resilience__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyResilienceModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_resilience/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_resilience/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_resilience/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_resilience/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_sleep": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Daily Sleep Documents",
+        "operationId": "Sandbox___Multiple_daily_sleep_Documents_v2_sandbox_usercollection_daily_sleep_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailySleep_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Daily Sleep Documents V2 Sandbox Usercollection Daily Sleep Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_sleep' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_sleep/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Daily Sleep Document",
+        "operationId": "Sandbox___Single_daily_sleep_Document_v2_sandbox_usercollection_daily_sleep__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailySleep"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_sleep/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_sleep/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_sleep/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_sleep/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_spo2": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Daily Spo2 Documents",
+        "operationId": "Sandbox___Multiple_daily_spo2_Documents_v2_sandbox_usercollection_daily_spo2_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailySpO2_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Daily Spo2 Documents V2 Sandbox Usercollection Daily Spo2 Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_spo2?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_spo2' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_spo2?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_spo2?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_spo2/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Daily Spo2 Document",
+        "operationId": "Sandbox___Single_daily_spo2_Document_v2_sandbox_usercollection_daily_spo2__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailySpO2"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_spo2/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_spo2/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_spo2/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_spo2/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_stress": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Daily Stress Documents",
+        "operationId": "Sandbox___Multiple_daily_stress_Documents_v2_sandbox_usercollection_daily_stress_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailyStress_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Daily Stress Documents V2 Sandbox Usercollection Daily Stress Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_stress?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_stress' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_stress?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_stress?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/daily_stress/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Daily Stress Document",
+        "operationId": "Sandbox___Single_daily_stress_Document_v2_sandbox_usercollection_daily_stress__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailyStress"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/daily_stress/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/daily_stress/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/daily_stress/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/daily_stress/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/enhanced_tag": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Enhanced Tag Documents",
+        "operationId": "Sandbox___Multiple_enhanced_tag_Documents_v2_sandbox_usercollection_enhanced_tag_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_EnhancedTagModel_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Enhanced Tag Documents V2 Sandbox Usercollection Enhanced Tag Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/enhanced_tag?start_date=2021-11-01&end_date=2021-12-01' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/enhanced_tag' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/enhanced_tag?start_date=2021-11-01&end_date=2021-12-01', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/enhanced_tag?start_date=2021-11-01&end_date=2021-12-01\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/enhanced_tag/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Enhanced Tag Document",
+        "operationId": "Sandbox___Single_enhanced_tag_Document_v2_sandbox_usercollection_enhanced_tag__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnhancedTagModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/enhanced_tag/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/enhanced_tag/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/enhanced_tag/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/enhanced_tag/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/heartrate": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Heartrate Documents",
+        "operationId": "Sandbox___Multiple_heartrate_Documents_v2_sandbox_usercollection_heartrate_get",
+        "parameters": [
+          {
+            "name": "start_datetime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Datetime"
+            }
+          },
+          {
+            "name": "end_datetime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Datetime"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/TimeSeriesResponse_PublicHeartRateRow_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TimeSeriesResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Heartrate Documents V2 Sandbox Usercollection Heartrate Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "# The '+' symbol in the timezone must be escaped to `%2B` if included. \ncurl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/heartrate?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm' \\ \n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/heartrate' \nparams={ \n    'start_datetime': '2021-11-01T00:00:00-08:00', \n    'end_datetime': '2021-12-01T00:00:00-08:00',\n    'fields': 'timestamp,bpm' \n} \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/heartrate?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/heartrate?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/rest_mode_period": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Rest Mode Period Documents",
+        "operationId": "Sandbox___Multiple_rest_mode_period_Documents_v2_sandbox_usercollection_rest_mode_period_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicRestModePeriod_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Rest Mode Period Documents V2 Sandbox Usercollection Rest Mode Period Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/rest_mode_period?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/rest_mode_period' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/rest_mode_period?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/rest_mode_period?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/rest_mode_period/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Rest Mode Period Document",
+        "operationId": "Sandbox___Single_rest_mode_period_Document_v2_sandbox_usercollection_rest_mode_period__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRestModePeriod"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/rest_mode_period/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/rest_mode_period/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/rest_mode_period/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/rest_mode_period/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/ring_battery_level": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Ring Battery Level Documents",
+        "operationId": "Sandbox___Multiple_ring_battery_level_Documents_v2_sandbox_usercollection_ring_battery_level_get",
+        "parameters": [
+          {
+            "name": "start_datetime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Datetime"
+            }
+          },
+          {
+            "name": "end_datetime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Datetime"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/TimeSeriesResponse_PublicRingBatteryLevelRow_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TimeSeriesResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Ring Battery Level Documents V2 Sandbox Usercollection Ring Battery Level Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "# The '+' symbol in the timezone must be escaped to `%2B` if included. \ncurl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/ring_battery_level?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm' \\ \n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/ring_battery_level' \nparams={ \n    'start_datetime': '2021-11-01T00:00:00-08:00', \n    'end_datetime': '2021-12-01T00:00:00-08:00',\n    'fields': 'timestamp,bpm' \n} \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/ring_battery_level?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/ring_battery_level?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/ring_configuration": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Ring Configuration Documents",
+        "operationId": "Sandbox___Multiple_ring_configuration_Documents_v2_sandbox_usercollection_ring_configuration_get",
+        "parameters": [
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicRingConfiguration_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Ring Configuration Documents V2 Sandbox Usercollection Ring Configuration Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/ring_configuration?fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/ring_configuration' \nparams = {'fields': 'day,score'}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/ring_configuration?fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/ring_configuration?fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/ring_configuration/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Ring Configuration Document",
+        "operationId": "Sandbox___Single_ring_configuration_Document_v2_sandbox_usercollection_ring_configuration__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRingConfiguration"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/ring_configuration/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/ring_configuration/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/ring_configuration/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/ring_configuration/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/session": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Session Documents",
+        "operationId": "Sandbox___Multiple_session_Documents_v2_sandbox_usercollection_session_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicSession_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Session Documents V2 Sandbox Usercollection Session Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/session?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/session' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/session?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/session?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/session/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Session Document",
+        "operationId": "Sandbox___Single_session_Document_v2_sandbox_usercollection_session__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSession"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/session/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/session/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/session/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/session/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/sleep": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Sleep Documents",
+        "operationId": "Sandbox___Multiple_sleep_Documents_v2_sandbox_usercollection_sleep_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicModifiedSleepModel_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Sleep Documents V2 Sandbox Usercollection Sleep Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/sleep' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/sleep/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Sleep Document",
+        "operationId": "Sandbox___Single_sleep_Document_v2_sandbox_usercollection_sleep__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicModifiedSleepModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/sleep/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/sleep/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/sleep/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/sleep/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/sleep_time": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Sleep Time Documents",
+        "operationId": "Sandbox___Multiple_sleep_time_Documents_v2_sandbox_usercollection_sleep_time_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicSleepTime_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Sleep Time Documents V2 Sandbox Usercollection Sleep Time Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/sleep_time?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/sleep_time' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/sleep_time?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/sleep_time?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/sleep_time/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Sleep Time Document",
+        "operationId": "Sandbox___Single_sleep_time_Document_v2_sandbox_usercollection_sleep_time__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSleepTime"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/sleep_time/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/sleep_time/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/sleep_time/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/sleep_time/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/tag": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Tag Documents",
+        "operationId": "Sandbox___Multiple_tag_Documents_v2_sandbox_usercollection_tag_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_TagModel_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Tag Documents V2 Sandbox Usercollection Tag Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/tag?start_date=2021-11-01&end_date=2021-12-01' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/tag' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/tag?start_date=2021-11-01&end_date=2021-12-01', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/tag?start_date=2021-11-01&end_date=2021-12-01\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/tag/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Tag Document",
+        "operationId": "Sandbox___Single_tag_Document_v2_sandbox_usercollection_tag__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/tag/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/tag/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/tag/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/tag/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/vO2_max": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Vo2 Max Documents",
+        "operationId": "Sandbox___Multiple_vO2_max_Documents_v2_sandbox_usercollection_vO2_max_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicVO2Max_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Vo2 Max Documents V2 Sandbox Usercollection Vo2 Max Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/vO2_max?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/vO2_max' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/vO2_max?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/vO2_max?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/vO2_max/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Vo2 Max Document",
+        "operationId": "Sandbox___Single_vO2_max_Document_v2_sandbox_usercollection_vO2_max__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicVO2Max"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/vO2_max/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/vO2_max/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/vO2_max/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/vO2_max/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/workout": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Multiple Workout Documents",
+        "operationId": "Sandbox___Multiple_workout_Documents_v2_sandbox_usercollection_workout_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicWorkout_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Sandbox   Multiple Workout Documents V2 Sandbox Usercollection Workout Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/workout?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/workout' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/workout?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/workout?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/sandbox/usercollection/workout/{document_id}": {
+      "get": {
+        "tags": [
+          "Sandbox Routes"
+        ],
+        "summary": "Sandbox - Single Workout Document",
+        "operationId": "Sandbox___Single_workout_Document_v2_sandbox_usercollection_workout__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicWorkout"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/sandbox/usercollection/workout/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/sandbox/usercollection/workout/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/sandbox/usercollection/workout/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/sandbox/usercollection/workout/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_activity": {
+      "get": {
+        "tags": [
+          "Daily Activity Routes"
+        ],
+        "summary": "Multiple Daily Activity Documents",
+        "operationId": "Multiple_daily_activity_Documents_v2_usercollection_daily_activity_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailyActivity_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Daily Activity Documents V2 Usercollection Daily Activity Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_activity?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_activity' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_activity?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_activity?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_activity/{document_id}": {
+      "get": {
+        "tags": [
+          "Daily Activity Routes"
+        ],
+        "summary": "Single Daily Activity Document",
+        "operationId": "Single_daily_activity_Document_v2_usercollection_daily_activity__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailyActivity"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_activity/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_activity/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_activity/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_activity/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_cardiovascular_age": {
+      "get": {
+        "tags": [
+          "Daily Cardiovascular Age Routes"
+        ],
+        "summary": "Multiple Daily Cardiovascular Age Documents",
+        "operationId": "Multiple_daily_cardiovascular_age_Documents_v2_usercollection_daily_cardiovascular_age_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailyCardiovascularAge_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Daily Cardiovascular Age Documents V2 Usercollection Daily Cardiovascular Age Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_cardiovascular_age?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_cardiovascular_age' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_cardiovascular_age?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_cardiovascular_age?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_cardiovascular_age/{document_id}": {
+      "get": {
+        "tags": [
+          "Daily Cardiovascular Age Routes"
+        ],
+        "summary": "Single Daily Cardiovascular Age Document",
+        "operationId": "Single_daily_cardiovascular_age_Document_v2_usercollection_daily_cardiovascular_age__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailyCardiovascularAge"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_cardiovascular_age/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_cardiovascular_age/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_cardiovascular_age/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_cardiovascular_age/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_readiness": {
+      "get": {
+        "tags": [
+          "Daily Readiness Routes"
+        ],
+        "summary": "Multiple Daily Readiness Documents",
+        "operationId": "Multiple_daily_readiness_Documents_v2_usercollection_daily_readiness_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailyReadiness_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Daily Readiness Documents V2 Usercollection Daily Readiness Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_readiness?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_readiness' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_readiness?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_readiness?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_readiness/{document_id}": {
+      "get": {
+        "tags": [
+          "Daily Readiness Routes"
+        ],
+        "summary": "Single Daily Readiness Document",
+        "operationId": "Single_daily_readiness_Document_v2_usercollection_daily_readiness__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailyReadiness"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_readiness/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_readiness/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_readiness/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_readiness/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_resilience": {
+      "get": {
+        "tags": [
+          "Daily Resilience Routes"
+        ],
+        "summary": "Multiple Daily Resilience Documents",
+        "operationId": "Multiple_daily_resilience_Documents_v2_usercollection_daily_resilience_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "N/A. This route does not support field selection yet, all fields will be returned.",
+              "title": "Fields"
+            },
+            "description": "N/A. This route does not support field selection yet, all fields will be returned."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_DailyResilienceModel_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Daily Resilience Documents V2 Usercollection Daily Resilience Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_resilience?start_date=2021-11-01&end_date=2021-12-01' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_resilience' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_resilience?start_date=2021-11-01&end_date=2021-12-01', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_resilience?start_date=2021-11-01&end_date=2021-12-01\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_resilience/{document_id}": {
+      "get": {
+        "tags": [
+          "Daily Resilience Routes"
+        ],
+        "summary": "Single Daily Resilience Document",
+        "operationId": "Single_daily_resilience_Document_v2_usercollection_daily_resilience__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyResilienceModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_resilience/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_resilience/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_resilience/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_resilience/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_sleep": {
+      "get": {
+        "tags": [
+          "Daily Sleep Routes"
+        ],
+        "summary": "Multiple Daily Sleep Documents",
+        "operationId": "Multiple_daily_sleep_Documents_v2_usercollection_daily_sleep_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailySleep_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Daily Sleep Documents V2 Usercollection Daily Sleep Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_sleep' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_sleep/{document_id}": {
+      "get": {
+        "tags": [
+          "Daily Sleep Routes"
+        ],
+        "summary": "Single Daily Sleep Document",
+        "operationId": "Single_daily_sleep_Document_v2_usercollection_daily_sleep__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailySleep"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_sleep/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_sleep/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_sleep/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_sleep/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_spo2": {
+      "get": {
+        "tags": [
+          "Daily Spo2 Routes"
+        ],
+        "summary": "Multiple Daily Spo2 Documents",
+        "operationId": "Multiple_daily_spo2_Documents_v2_usercollection_daily_spo2_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailySpO2_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Daily Spo2 Documents V2 Usercollection Daily Spo2 Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_spo2?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_spo2' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_spo2?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_spo2?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_spo2/{document_id}": {
+      "get": {
+        "tags": [
+          "Daily Spo2 Routes"
+        ],
+        "summary": "Single Daily Spo2 Document",
+        "operationId": "Single_daily_spo2_Document_v2_usercollection_daily_spo2__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailySpO2"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_spo2/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_spo2/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_spo2/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_spo2/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_stress": {
+      "get": {
+        "tags": [
+          "Daily Stress Routes"
+        ],
+        "summary": "Multiple Daily Stress Documents",
+        "operationId": "Multiple_daily_stress_Documents_v2_usercollection_daily_stress_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicDailyStress_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Daily Stress Documents V2 Usercollection Daily Stress Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_stress?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_stress' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_stress?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_stress?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/daily_stress/{document_id}": {
+      "get": {
+        "tags": [
+          "Daily Stress Routes"
+        ],
+        "summary": "Single Daily Stress Document",
+        "operationId": "Single_daily_stress_Document_v2_usercollection_daily_stress__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDailyStress"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/daily_stress/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/daily_stress/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/daily_stress/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/daily_stress/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/enhanced_tag": {
+      "get": {
+        "tags": [
+          "Enhanced Tag Routes"
+        ],
+        "summary": "Multiple Enhanced Tag Documents",
+        "operationId": "Multiple_enhanced_tag_Documents_v2_usercollection_enhanced_tag_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "N/A. This route does not support field selection yet, all fields will be returned.",
+              "title": "Fields"
+            },
+            "description": "N/A. This route does not support field selection yet, all fields will be returned."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_EnhancedTagModel_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Enhanced Tag Documents V2 Usercollection Enhanced Tag Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/enhanced_tag?start_date=2021-11-01&end_date=2021-12-01' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/enhanced_tag' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/enhanced_tag?start_date=2021-11-01&end_date=2021-12-01', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/enhanced_tag?start_date=2021-11-01&end_date=2021-12-01\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/enhanced_tag/{document_id}": {
+      "get": {
+        "tags": [
+          "Enhanced Tag Routes"
+        ],
+        "summary": "Single Enhanced Tag Document",
+        "operationId": "Single_enhanced_tag_Document_v2_usercollection_enhanced_tag__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnhancedTagModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/enhanced_tag/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/enhanced_tag/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/enhanced_tag/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/enhanced_tag/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/heartrate": {
+      "get": {
+        "tags": [
+          "Heart Rate Routes"
+        ],
+        "summary": "Multiple Heartrate Documents",
+        "operationId": "Multiple_heartrate_Documents_v2_usercollection_heartrate_get",
+        "parameters": [
+          {
+            "name": "start_datetime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Datetime"
+            }
+          },
+          {
+            "name": "end_datetime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Datetime"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "latest",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "If True, returns most recent sample.",
+              "title": "Latest"
+            },
+            "description": "If True, returns most recent sample."
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/TimeSeriesResponse_PublicHeartRateRow_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TimeSeriesResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Heartrate Documents V2 Usercollection Heartrate Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "# The '+' symbol in the timezone must be escaped to `%2B` if included. \ncurl --location --request GET 'https://api.ouraring.com/v2/usercollection/heartrate?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm' \\ \n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/heartrate' \nparams={ \n    'start_datetime': '2021-11-01T00:00:00-08:00', \n    'end_datetime': '2021-12-01T00:00:00-08:00',\n    'fields': 'timestamp,bpm' \n} \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/heartrate?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/heartrate?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/personal_info": {
+      "get": {
+        "tags": [
+          "Personal Info Routes"
+        ],
+        "summary": "Single Personal Info Document",
+        "operationId": "Single_Personal_Info_Document_v2_usercollection_personal_info_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonalInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/personal_info' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/personal_info' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders,\n}; \nfetch('https://api.ouraring.com/v2/usercollection/personal_info', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/personal_info\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/rest_mode_period": {
+      "get": {
+        "tags": [
+          "Rest Mode Period Routes"
+        ],
+        "summary": "Multiple Rest Mode Period Documents",
+        "operationId": "Multiple_rest_mode_period_Documents_v2_usercollection_rest_mode_period_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicRestModePeriod_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Rest Mode Period Documents V2 Usercollection Rest Mode Period Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/rest_mode_period?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/rest_mode_period' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/rest_mode_period?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/rest_mode_period?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/rest_mode_period/{document_id}": {
+      "get": {
+        "tags": [
+          "Rest Mode Period Routes"
+        ],
+        "summary": "Single Rest Mode Period Document",
+        "operationId": "Single_rest_mode_period_Document_v2_usercollection_rest_mode_period__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRestModePeriod"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/rest_mode_period/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/rest_mode_period/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/rest_mode_period/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/rest_mode_period/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/ring_battery_level": {
+      "get": {
+        "tags": [
+          "Ring Battery Level Routes"
+        ],
+        "summary": "Multiple Ring Battery Level Documents",
+        "operationId": "Multiple_ring_battery_level_Documents_v2_usercollection_ring_battery_level_get",
+        "parameters": [
+          {
+            "name": "start_datetime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Datetime"
+            }
+          },
+          {
+            "name": "end_datetime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Datetime"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "latest",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "If True, returns most recent sample.",
+              "title": "Latest"
+            },
+            "description": "If True, returns most recent sample."
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/TimeSeriesResponse_PublicRingBatteryLevelRow_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TimeSeriesResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Ring Battery Level Documents V2 Usercollection Ring Battery Level Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "# The '+' symbol in the timezone must be escaped to `%2B` if included. \ncurl --location --request GET 'https://api.ouraring.com/v2/usercollection/ring_battery_level?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm' \\ \n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/ring_battery_level' \nparams={ \n    'start_datetime': '2021-11-01T00:00:00-08:00', \n    'end_datetime': '2021-12-01T00:00:00-08:00',\n    'fields': 'timestamp,bpm' \n} \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/ring_battery_level?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/ring_battery_level?start_datetime=2021-11-01T00:00:00-08:00&end_datetime=2021-12-01T00:00:00-08:00&fields=timestamp,bpm\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/ring_configuration": {
+      "get": {
+        "tags": [
+          "Ring Configuration Routes"
+        ],
+        "summary": "Multiple Ring Configuration Documents",
+        "operationId": "Multiple_ring_configuration_Documents_v2_usercollection_ring_configuration_get",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicRingConfiguration_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Ring Configuration Documents V2 Usercollection Ring Configuration Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/ring_configuration?fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/ring_configuration' \nparams = {'fields': 'day,score'}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/ring_configuration?fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/ring_configuration?fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/ring_configuration/{document_id}": {
+      "get": {
+        "tags": [
+          "Ring Configuration Routes"
+        ],
+        "summary": "Single Ring Configuration Document",
+        "operationId": "Single_ring_configuration_Document_v2_usercollection_ring_configuration__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRingConfiguration"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/ring_configuration/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/ring_configuration/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/ring_configuration/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/ring_configuration/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/session": {
+      "get": {
+        "tags": [
+          "Session Routes"
+        ],
+        "summary": "Multiple Session Documents",
+        "operationId": "Multiple_session_Documents_v2_usercollection_session_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicSession_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Session Documents V2 Usercollection Session Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/session?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/session' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/session?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/session?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/session/{document_id}": {
+      "get": {
+        "tags": [
+          "Session Routes"
+        ],
+        "summary": "Single Session Document",
+        "operationId": "Single_session_Document_v2_usercollection_session__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSession"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/session/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/session/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/session/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/session/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/sleep": {
+      "get": {
+        "tags": [
+          "Sleep Routes"
+        ],
+        "summary": "Multiple Sleep Documents",
+        "operationId": "Multiple_sleep_Documents_v2_usercollection_sleep_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicModifiedSleepModel_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Sleep Documents V2 Usercollection Sleep Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/sleep' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/sleep?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/sleep/{document_id}": {
+      "get": {
+        "tags": [
+          "Sleep Routes"
+        ],
+        "summary": "Single Sleep Document",
+        "operationId": "Single_sleep_Document_v2_usercollection_sleep__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicModifiedSleepModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/sleep/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/sleep/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/sleep/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/sleep/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/sleep_time": {
+      "get": {
+        "tags": [
+          "Sleep Time Routes"
+        ],
+        "summary": "Multiple Sleep Time Documents",
+        "operationId": "Multiple_sleep_time_Documents_v2_usercollection_sleep_time_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicSleepTime_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Sleep Time Documents V2 Usercollection Sleep Time Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/sleep_time?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/sleep_time' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/sleep_time?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/sleep_time?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/sleep_time/{document_id}": {
+      "get": {
+        "tags": [
+          "Sleep Time Routes"
+        ],
+        "summary": "Single Sleep Time Document",
+        "operationId": "Single_sleep_time_Document_v2_usercollection_sleep_time__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSleepTime"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/sleep_time/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/sleep_time/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/sleep_time/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/sleep_time/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/tag": {
+      "get": {
+        "tags": [
+          "Tag Routes"
+        ],
+        "summary": "Multiple Tag Documents",
+        "operationId": "Multiple_tag_Documents_v2_usercollection_tag_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "N/A. This route does not support field selection yet, all fields will be returned.",
+              "title": "Fields"
+            },
+            "description": "N/A. This route does not support field selection yet, all fields will be returned."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_TagModel_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Tag Documents V2 Usercollection Tag Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/tag?start_date=2021-11-01&end_date=2021-12-01' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/tag' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/tag?start_date=2021-11-01&end_date=2021-12-01', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/tag?start_date=2021-11-01&end_date=2021-12-01\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/tag/{document_id}": {
+      "get": {
+        "tags": [
+          "Tag Routes"
+        ],
+        "summary": "Single Tag Document",
+        "operationId": "Single_tag_Document_v2_usercollection_tag__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/tag/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/tag/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/tag/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/tag/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/vO2_max": {
+      "get": {
+        "tags": [
+          "VO2 Max Routes"
+        ],
+        "summary": "Multiple Vo2 Max Documents",
+        "operationId": "Multiple_vO2_max_Documents_v2_usercollection_vO2_max_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicVO2Max_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Vo2 Max Documents V2 Usercollection Vo2 Max Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/vO2_max?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/vO2_max' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/vO2_max?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/vO2_max?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/vO2_max/{document_id}": {
+      "get": {
+        "tags": [
+          "VO2 Max Routes"
+        ],
+        "summary": "Single Vo2 Max Document",
+        "operationId": "Single_vO2_max_Document_v2_usercollection_vO2_max__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicVO2Max"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/vO2_max/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/vO2_max/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/vO2_max/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/vO2_max/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/workout": {
+      "get": {
+        "tags": [
+          "Workout Routes"
+        ],
+        "summary": "Multiple Workout Documents",
+        "operationId": "Multiple_workout_Documents_v2_usercollection_workout_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          },
+          {
+            "name": "next_token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Next Token"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided.",
+              "title": "Fields"
+            },
+            "description": "Comma-separated list of fields to include in the response, in addition to the always returned fields. Defaults to all fields if not provided."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponse_PublicWorkout_"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MultiDocumentResponseDict"
+                    }
+                  ],
+                  "title": "Response Multiple Workout Documents V2 Usercollection Workout Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/workout?start_date=2021-11-01&end_date=2021-12-01&fields=day,score' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/workout' \nparams={ \n    'start_date': '2021-11-01', \n    'end_date': '2021-12-01',\n    'fields': 'day,score' \n}\nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/workout?start_date=2021-11-01&end_date=2021-12-01&fields=day,score', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/workout?start_date=2021-11-01&end_date=2021-12-01&fields=day,score\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/usercollection/workout/{document_id}": {
+      "get": {
+        "tags": [
+          "Workout Routes"
+        ],
+        "summary": "Single Workout Document",
+        "operationId": "Single_workout_Document_v2_usercollection_workout__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicWorkout"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "400": {
+            "description": "Client Exception"
+          },
+          "401": {
+            "description": "Unauthorized access exception. Usually means the access token is expired, malformed or revoked."
+          },
+          "403": {
+            "description": "Access forbidden. Usually means the user's subscription to Oura has expired and their data is not available via the API."
+          },
+          "429": {
+            "description": "Request Rate Limit Exceeded."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/usercollection/workout/2-5daccc095220cc5493a4e9c2b681ca941e' \\\n--header 'Authorization: Bearer <token>'"
+          },
+          {
+            "lang": "Python",
+            "source": "import requests \nurl = 'https://api.ouraring.com/v2/usercollection/workout/2-5daccc095220cc5493a4e9c2b681ca941e' \nheaders = { \n  'Authorization': 'Bearer <token>' \n}\nresponse = requests.request('GET', url, headers=headers, params=params) \nprint(response.text)",
+            "label": "Python"
+          },
+          {
+            "lang": "JavaScript",
+            "source": "var myHeaders = new Headers(); \nmyHeaders.append('Authorization', 'Bearer <token>'); \nvar requestOptions = { \n  method: 'GET', \n  headers: myHeaders, \n}; \nfetch('https://api.ouraring.com/v2/usercollection/workout/2-5daccc095220cc5493a4e9c2b681ca941e', requestOptions) \n  .then(response => response.text()) \n  .then(result => console.log(result)) \n  .catch(error => console.log('error', error));",
+            "label": "JavaScript"
+          },
+          {
+            "lang": "Java",
+            "source": "OkHttpClient client = new OkHttpClient().newBuilder() \n  .build(); \nRequest request = new Request.Builder() \n  .url(\"https://api.ouraring.com/v2/usercollection/workout/2-5daccc095220cc5493a4e9c2b681ca941e\") \n  .method(\"GET\", null) \n  .addHeader(\"Authorization\", \"Bearer <token>\") \n  .build(); \nResponse response = client.newCall(request).execute();",
+            "label": "Java"
+          }
+        ]
+      }
+    },
+    "/v2/webhook/subscription": {
+      "get": {
+        "tags": [
+          "Webhook Subscription Routes"
+        ],
+        "summary": "List Webhook Subscriptions",
+        "operationId": "list_webhook_subscriptions_v2_webhook_subscription_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/WebhookSubscriptionModel"
+                  },
+                  "type": "array",
+                  "title": "Response List Webhook Subscriptions V2 Webhook Subscription Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ClientIdAuth": [],
+            "ClientSecretAuth": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/webhook/subscription' --header 'x-client-id: client-id' --header 'x-client-secret: client-secret'"
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Webhook Subscription Routes"
+        ],
+        "summary": "Create Webhook Subscription",
+        "operationId": "create_webhook_subscription_v2_webhook_subscription_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWebhookSubscriptionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookSubscriptionModel"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ClientIdAuth": [],
+            "ClientSecretAuth": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request POST 'https://api.ouraring.com/v2/webhook/subscription' --header 'x-client-id: client-id' --header 'x-client-secret: client-secret' --header 'Content-Type: application/json' --data-raw '{\n    \"callback_url\": \"https://my-api/oura/tag/delete\",\n    \"verification_token\": \"123\",\n    \"event_type\": \"delete\",\n    \"data_type\": \"tag\"\n}'"
+          }
+        ]
+      }
+    },
+    "/v2/webhook/subscription/renew/{id}": {
+      "put": {
+        "tags": [
+          "Webhook Subscription Routes"
+        ],
+        "summary": "Renew Webhook Subscription",
+        "operationId": "renew_webhook_subscription_v2_webhook_subscription_renew__id__put",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookSubscriptionModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Webhook with specified id does not exist."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ClientIdAuth": [],
+            "ClientSecretAuth": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request PUT 'https://api.ouraring.com/v2/webhook/subscription/renew/5d3fe17b-f880-4d93-b9b6-afbfb76c1e78' --header 'x-client-id: client-id' --header 'x-client-secret: client-secret' --header 'Content-Type: application/json'"
+          }
+        ]
+      }
+    },
+    "/v2/webhook/subscription/{id}": {
+      "get": {
+        "tags": [
+          "Webhook Subscription Routes"
+        ],
+        "summary": "Get Webhook Subscription",
+        "operationId": "get_webhook_subscription_v2_webhook_subscription__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookSubscriptionModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Webhook with specified id does not exist."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ClientIdAuth": [],
+            "ClientSecretAuth": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request GET 'https://api.ouraring.com/v2/webhook/subscription/5d3fe17b-f880-4d93-b9b6-afbfb76c1e78' --header 'x-client-id: client-id' --header 'x-client-secret: client-secret'"
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Webhook Subscription Routes"
+        ],
+        "summary": "Update Webhook Subscription",
+        "operationId": "update_webhook_subscription_v2_webhook_subscription__id__put",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWebhookSubscriptionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookSubscriptionModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Webhook with specified id does not exist."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ClientIdAuth": [],
+            "ClientSecretAuth": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request PUT 'https://api.ouraring.com/v2/webhook/subscription/5d3fe17b-f880-4d93-b9b6-afbfb76c1e78' --header 'x-client-id: client-id' --header 'x-client-secret: client-secret' --header 'Content-Type: application/json' --data-raw '{\n    \"callback_url\": \"https://my-api/oura/tag/delete\",\n    \"verification_token\": \"123\",\n    \"event_type\": \"delete\",\n    \"data_type\": \"tag\"\n}'"
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Webhook Subscription Routes"
+        ],
+        "summary": "Delete Webhook Subscription",
+        "operationId": "delete_webhook_subscription_v2_webhook_subscription__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "403": {
+            "description": "Webhook with specified id does not exist."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ClientIdAuth": [],
+            "ClientSecretAuth": []
+          }
+        ],
+        "x-codeSamples": [
+          {
+            "lang": "cURL",
+            "label": "cURL",
+            "source": "curl --location --request DELETE 'https://api.ouraring.com/v2/webhook/subscription/5d3fe17b-f880-4d93-b9b6-afbfb76c1e78' --header 'x-client-id: client-id' --header 'x-client-secret: client-secret'"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Array_Union_float__NoneType__Bits64_": {
+        "items": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": "array",
+        "title": "ArrayNullableFloatBits64"
+      },
+      "CreateWebhookSubscriptionRequest": {
+        "properties": {
+          "callback_url": {
+            "type": "string",
+            "title": "Callback Url"
+          },
+          "verification_token": {
+            "type": "string",
+            "title": "Verification Token"
+          },
+          "event_type": {
+            "$ref": "#/components/schemas/WebhookOperation"
+          },
+          "data_type": {
+            "$ref": "#/components/schemas/ExtApiV2DataType"
+          }
+        },
+        "type": "object",
+        "required": [
+          "callback_url",
+          "verification_token",
+          "event_type",
+          "data_type"
+        ],
+        "title": "CreateWebhookSubscriptionRequest"
+      },
+      "DailyResilienceModel": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "day": {
+            "type": "string",
+            "format": "date",
+            "title": "Day",
+            "description": "Day when the resilience record was recorded."
+          },
+          "contributors": {
+            "$ref": "#/components/schemas/ResilienceContributors",
+            "description": "Contributors to the resilience score."
+          },
+          "level": {
+            "$ref": "#/components/schemas/LongTermResilienceLevel",
+            "description": "Resilience level."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "day",
+          "contributors",
+          "level"
+        ],
+        "title": "DailyResilienceModel"
+      },
+      "EnhancedTagModel": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "tag_type_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Type Code",
+            "description": "The unique code of the selected tag type, `NULL` for text-only tags, or `custom` for custom tag types."
+          },
+          "start_time": {
+            "$ref": "#/components/schemas/LocalDateTime",
+            "description": "Timestamp of the tag (if no duration) or the start time of the tag (with duration)."
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LocalDateTime"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Timestamp of the tag's end for events with duration or `NULL` if there is no duration."
+          },
+          "start_day": {
+            "type": "string",
+            "format": "date",
+            "title": "Start Day",
+            "description": "Day of the tag (if no duration) or the start day of the tag (with duration)."
+          },
+          "end_day": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Day",
+            "description": "Day of the tag's end for events with duration or `NULL` if there is no duration."
+          },
+          "comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comment",
+            "description": "Additional freeform text on the tag."
+          },
+          "custom_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Name",
+            "description": "The name of the tag if the tag_type_code is `custom`."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "start_time",
+          "start_day"
+        ],
+        "title": "EnhancedTagModel",
+        "description": "An EnhancedTagModel maps an ASSATag. An ASSATag in ExtAPIV2 is called a EnhancedTag\nAn EnhancedTagModel will be populated by data from an ASSATag\nThe fields in the EnhancedTagModel map to fields in an ASSATag"
+      },
+      "ExtApiV2DataType": {
+        "type": "string",
+        "enum": [
+          "tag",
+          "enhanced_tag",
+          "workout",
+          "session",
+          "sleep",
+          "daily_sleep",
+          "daily_readiness",
+          "daily_activity",
+          "daily_spo2",
+          "sleep_time",
+          "rest_mode_period",
+          "ring_configuration",
+          "daily_stress",
+          "daily_cardiovascular_age",
+          "daily_resilience",
+          "vo2_max",
+          "meal"
+        ],
+        "title": "ExtApiV2DataType"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ISODate": {
+        "type": "string"
+      },
+      "LocalDateTime": {
+        "type": "string"
+      },
+      "LocalizedDateTime": {
+        "type": "string"
+      },
+      "LongTermResilienceLevel": {
+        "type": "string",
+        "enum": [
+          "limited",
+          "adequate",
+          "solid",
+          "strong",
+          "exceptional"
+        ],
+        "title": "LongTermResilienceLevel",
+        "description": "Possible long term resilience level values."
+      },
+      "MultiDocumentResponseDict": {
+        "properties": {
+          "data": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponseDict"
+      },
+      "MultiDocumentResponse_DailyResilienceModel_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DailyResilienceModel"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[DailyResilienceModel]"
+      },
+      "MultiDocumentResponse_EnhancedTagModel_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/EnhancedTagModel"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[EnhancedTagModel]"
+      },
+      "MultiDocumentResponse_PublicDailyActivity_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicDailyActivity"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicDailyActivity]"
+      },
+      "MultiDocumentResponse_PublicDailyCardiovascularAge_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicDailyCardiovascularAge"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicDailyCardiovascularAge]"
+      },
+      "MultiDocumentResponse_PublicDailyReadiness_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicDailyReadiness"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicDailyReadiness]"
+      },
+      "MultiDocumentResponse_PublicDailySleep_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicDailySleep"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicDailySleep]"
+      },
+      "MultiDocumentResponse_PublicDailySpO2_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicDailySpO2"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicDailySpO2]"
+      },
+      "MultiDocumentResponse_PublicDailyStress_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicDailyStress"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicDailyStress]"
+      },
+      "MultiDocumentResponse_PublicModifiedSleepModel_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicModifiedSleepModel"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicModifiedSleepModel]"
+      },
+      "MultiDocumentResponse_PublicRestModePeriod_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicRestModePeriod"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicRestModePeriod]"
+      },
+      "MultiDocumentResponse_PublicRingConfiguration_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicRingConfiguration"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicRingConfiguration]"
+      },
+      "MultiDocumentResponse_PublicSession_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicSession"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicSession]"
+      },
+      "MultiDocumentResponse_PublicSleepTime_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicSleepTime"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicSleepTime]"
+      },
+      "MultiDocumentResponse_PublicVO2Max_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicVO2Max"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicVO2Max]"
+      },
+      "MultiDocumentResponse_PublicWorkout_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicWorkout"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[PublicWorkout]"
+      },
+      "MultiDocumentResponse_TagModel_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TagModel"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "next_token"
+        ],
+        "title": "MultiDocumentResponse[TagModel]"
+      },
+      "PersonalInfoResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "age": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Age"
+          },
+          "weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight"
+          },
+          "height": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Height"
+          },
+          "biological_sex": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Biological Sex"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "PersonalInfoResponse"
+      },
+      "PublicActivityContributors": {
+        "properties": {
+          "meet_daily_targets": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of meeting previous 7-day daily activity targets in range [1, 100]."
+          },
+          "move_every_hour": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of previous 24-hour inactivity alerts in range [1, 100]."
+          },
+          "recovery_time": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of previous 7-day recovery time in range [1, 100]."
+          },
+          "stay_active": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of previous 24-hour activity in range [1, 100]."
+          },
+          "training_frequency": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of previous 7-day exercise frequency in range [1, 100]."
+          },
+          "training_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of previous 7-day exercise volume in range [1, 100]."
+          }
+        },
+        "type": "object",
+        "title": "PublicActivityContributors",
+        "description": "Object defining activity score contributors."
+      },
+      "PublicDailyActivity": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "active_calories": {
+            "type": "integer",
+            "title": "",
+            "description": "Active calories expended in kilocalories."
+          },
+          "average_met_minutes": {
+            "type": "number",
+            "title": "",
+            "description": "Average MET minutes."
+          },
+          "class_5_min": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "5-minute activity classification for the period where every character corresponds to:\n'0' = non wear\n'1' = rest\n'2' = inactive\n'3' = low activity\n'4' = medium activity\n'5' = high activity\nExample: \"001233334555524001\"."
+          },
+          "contributors": {
+            "$ref": "#/components/schemas/PublicActivityContributors",
+            "title": "",
+            "description": "Object containing activity score contributors."
+          },
+          "day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "Day that the daily activity belong to."
+          },
+          "equivalent_walking_distance": {
+            "type": "integer",
+            "title": "",
+            "description": "Equivalent walking distance of energe expenditure in meters."
+          },
+          "high_activity_met_minutes": {
+            "type": "integer",
+            "title": "",
+            "description": "The total METs of each minute classified as high activity."
+          },
+          "high_activity_time": {
+            "type": "integer",
+            "title": "",
+            "description": "The total time in seconds of each minute classified as high activity."
+          },
+          "inactivity_alerts": {
+            "type": "integer",
+            "title": "",
+            "description": "Number of inactivity alerts received."
+          },
+          "low_activity_met_minutes": {
+            "type": "integer",
+            "title": "",
+            "description": "The total METs of each minute classified as low activity."
+          },
+          "low_activity_time": {
+            "type": "integer",
+            "title": "",
+            "description": "The total time in seconds of each minute classified as low activity."
+          },
+          "medium_activity_met_minutes": {
+            "type": "integer",
+            "title": "",
+            "description": "The total METs of each minute classified as medium activity."
+          },
+          "medium_activity_time": {
+            "type": "integer",
+            "title": "",
+            "description": "The total time in seconds of each minute classified as medium activity."
+          },
+          "met": {
+            "$ref": "#/components/schemas/PublicSample",
+            "title": "",
+            "description": "Sample containing METs."
+          },
+          "meters_to_target": {
+            "type": "integer",
+            "title": "",
+            "description": "Meters remaining to target."
+          },
+          "non_wear_time": {
+            "type": "integer",
+            "title": "",
+            "description": "Ring non-wear time in seconds."
+          },
+          "resting_time": {
+            "type": "integer",
+            "title": "",
+            "description": "Resting time in seconds."
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Activity score in range [1, 100]."
+          },
+          "sedentary_met_minutes": {
+            "type": "integer",
+            "title": "",
+            "description": "Sedentary MET minutes."
+          },
+          "sedentary_time": {
+            "type": "integer",
+            "title": "",
+            "description": "Sedentary time in seconds."
+          },
+          "steps": {
+            "type": "integer",
+            "title": "",
+            "description": "Total number of steps taken."
+          },
+          "target_calories": {
+            "type": "integer",
+            "title": "",
+            "description": "Daily activity target in kilocalories."
+          },
+          "target_meters": {
+            "type": "integer",
+            "title": "",
+            "description": "Daily activity target in meters."
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Timestamp of the daily activity."
+          },
+          "total_calories": {
+            "type": "integer",
+            "title": "",
+            "description": "Total calories expended in kilocalories."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "active_calories",
+          "average_met_minutes",
+          "contributors",
+          "day",
+          "equivalent_walking_distance",
+          "high_activity_met_minutes",
+          "high_activity_time",
+          "inactivity_alerts",
+          "low_activity_met_minutes",
+          "low_activity_time",
+          "medium_activity_met_minutes",
+          "medium_activity_time",
+          "met",
+          "meters_to_target",
+          "non_wear_time",
+          "resting_time",
+          "sedentary_met_minutes",
+          "sedentary_time",
+          "steps",
+          "target_calories",
+          "target_meters",
+          "timestamp",
+          "total_calories"
+        ],
+        "title": "PublicDailyActivity",
+        "description": "Object defining a daily activity that is a 24-hour period starting at 4 a.m.",
+        "x-cloud-only": true,
+        "x-collection": "publicdailyactivity",
+        "x-owner": "movement-squad"
+      },
+      "PublicDailyCardiovascularAge": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "Day that the prediction belongs to."
+          },
+          "pulse_wave_velocity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Pulse wave velocity (m/s), derived from vascular age, with possible offset added."
+          },
+          "vascular_age": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Predicted vascular age in range [18, 100]."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "day"
+        ],
+        "title": "PublicDailyCardiovascularAge",
+        "description": "Daily Cardiovascular Age.",
+        "x-cloud-only": true,
+        "x-collection": "publicdailycardiovascularage",
+        "x-owner": "heart-health-squad"
+      },
+      "PublicDailyReadiness": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "contributors": {
+            "$ref": "#/components/schemas/PublicReadinessContributors",
+            "title": "",
+            "description": "Contributors of the daily readiness score."
+          },
+          "day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "Day that the daily readiness belongs to."
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Daily readiness score."
+          },
+          "temperature_deviation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Temperature deviation in degrees Celsius."
+          },
+          "temperature_trend_deviation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Temperature trend deviation in degrees Celsius."
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Timestamp of the daily readiness."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "contributors",
+          "day",
+          "timestamp"
+        ],
+        "title": "PublicDailyReadiness",
+        "description": "Public object defining daily readiness.",
+        "x-cloud-only": true,
+        "x-collection": "publicdailyreadiness",
+        "x-owner": "wellbeing-squad"
+      },
+      "PublicDailySleep": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "contributors": {
+            "$ref": "#/components/schemas/PublicSleepContributors",
+            "title": "",
+            "description": "Contributors for the daily sleep score."
+          },
+          "day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "Day that the daily sleep belongs to."
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Daily sleep score."
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Timestamp of the daily sleep."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "contributors",
+          "day",
+          "timestamp"
+        ],
+        "title": "PublicDailySleep",
+        "description": "Public object defining daily sleep.",
+        "x-cloud-only": true,
+        "x-collection": "publicdailysleep",
+        "x-owner": "sleep-squad"
+      },
+      "PublicDailySpO2": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "breathing_disturbance_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Breathing Disturbance Index (BDI) calculated using detected SpO2 drops from timeseries. Values should be in range [0, 100]"
+          },
+          "day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "Day that the spo2 values belong to."
+          },
+          "spo2_percentage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSpo2AggregatedValues"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "The daily SpO2 percentage value aggregates. Sourced from SpO2 percentage timeseries values."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "day"
+        ],
+        "title": "PublicDailySpO2",
+        "description": "Daily SpO2 (Oxygen saturation).",
+        "x-cloud-only": true,
+        "x-collection": "publicdailyspo2",
+        "x-owner": "sleep-squad"
+      },
+      "PublicDailyStress": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "Day that the daily stress belongs to."
+          },
+          "day_summary": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicDailyStressSummary"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Stress summary of full day."
+          },
+          "recovery_high": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Time spent in a high recovery zone (bottom quartile data) in seconds."
+          },
+          "stress_high": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Time spent in a high stress zone (top quartile of data) in seconds."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "day"
+        ],
+        "title": "PublicDailyStress",
+        "description": "Daily stress.",
+        "x-cloud-only": true,
+        "x-collection": "publicdailystress",
+        "x-owner": "wellbeing-squad"
+      },
+      "PublicDailyStressSummary": {
+        "type": "string",
+        "enum": [
+          "restored",
+          "normal",
+          "stressful"
+        ],
+        "title": "PublicDailyStressSummary",
+        "description": "Possible public daily stress summary types."
+      },
+      "PublicHeartRateRow": {
+        "properties": {
+          "timestamp": {
+            "$ref": "#/components/schemas/UtcDateTime",
+            "title": "",
+            "description": "Timestamp of the discrete sample."
+          },
+          "timestamp_unix": {
+            "type": "integer",
+            "title": "",
+            "description": "Timestamp of the discrete sample as unix time in milliseconds."
+          },
+          "bpm": {
+            "type": "integer",
+            "title": "",
+            "description": "Heart rate as beats per minute."
+          },
+          "source": {
+            "$ref": "#/components/schemas/PublicHeartRateSource",
+            "title": "",
+            "description": "Source of the sample."
+          }
+        },
+        "type": "object",
+        "required": [
+          "timestamp",
+          "timestamp_unix",
+          "bpm",
+          "source"
+        ],
+        "title": "PublicHeartRateRow",
+        "description": "Heart rate sample",
+        "x-cloud-only": true,
+        "x-collection": "publicheartrate",
+        "x-owner": "core-sensing-squad"
+      },
+      "PublicHeartRateSource": {
+        "type": "string",
+        "enum": [
+          "awake",
+          "workout",
+          "rest",
+          "sleep",
+          "live",
+          "session"
+        ],
+        "title": "PublicHeartRateSource",
+        "description": "Possible heart rate sources."
+      },
+      "PublicModifiedSleepModel": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "average_breath": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Average breathing rate during sleep as breaths/minute."
+          },
+          "average_heart_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Average heart rate during sleep as beats/minute. NOTE: this is the average calculated by ecore (based on 30-second samples) which is different from what is shown in the app. The app shows the average of aggregated 5-minute heart rate samples."
+          },
+          "average_hrv": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Average heart rate variability during sleep."
+          },
+          "awake_time": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Duration spent awake in seconds."
+          },
+          "bedtime_end": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Bedtime end of the sleep."
+          },
+          "bedtime_start": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Bedtime start of the sleep."
+          },
+          "day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "Day that the sleep belongs to."
+          },
+          "deep_sleep_duration": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Duration spent in deep sleep in seconds."
+          },
+          "efficiency": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Sleep efficiency rating in range [1, 100]."
+          },
+          "heart_rate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSample"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Object containing heart rate samples."
+          },
+          "hrv": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSample"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Object containing heart rate variability samples."
+          },
+          "latency": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Sleep latency in seconds. This is the time it took for the user to fall asleep after going to bed."
+          },
+          "light_sleep_duration": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Duration spent in light sleep in seconds."
+          },
+          "low_battery_alert": {
+            "type": "boolean",
+            "title": "",
+            "description": "Flag indicating if a low battery alert occurred."
+          },
+          "lowest_heart_rate": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Lowest heart rate during sleep. NOTE: this is the value calculated by ecore (based on 30-second samples) which is different from what is shown in the app. The app shows the minimum of aggregated 5-minute heart rate samples."
+          },
+          "movement_30_sec": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "30-second movement classification for the period where every character corresponds to:\n'1' = no motion,\n'2' = restless,\n'3' = tossing and turning\n'4' = active\nExample: \"1143222134\"."
+          },
+          "period": {
+            "type": "integer",
+            "title": "",
+            "description": "ECore sleep period identifier."
+          },
+          "readiness": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicReadiness"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Object containing the readiness details."
+          },
+          "readiness_score_delta": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Effect on readiness score caused by this sleep period."
+          },
+          "rem_sleep_duration": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Duration spent in REM sleep in seconds."
+          },
+          "restless_periods": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Number of restless periods during sleep."
+          },
+          "sleep_algorithm_version": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSleepAlgorithmVersion"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Version of the sleep algorithm used to calculate the sleep data."
+          },
+          "sleep_analysis_reason": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSleepAnalysisReason"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "The reason for the creation or update of the latest version of this sleep."
+          },
+          "sleep_phase_30_sec": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "30-second sleep phase classification for the period where every character corresponds to:\n'1' = deep sleep,\n'2' = light sleep,\n'3' = REM sleep\n'4' = awake.\nExample: \"444423323441114\"."
+          },
+          "sleep_phase_5_min": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "5-minute sleep phase classification for the period where every character corresponds to:\n'1' = deep sleep,\n'2' = light sleep,\n'3' = REM sleep\n'4' = awake.\nExample: \"444423323441114\"."
+          },
+          "sleep_score_delta": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Effect on sleep score caused by this sleep period."
+          },
+          "time_in_bed": {
+            "type": "integer",
+            "title": "",
+            "description": "Duration spent in bed in seconds."
+          },
+          "total_sleep_duration": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Total sleep duration in seconds."
+          },
+          "type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSleepType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Type of the sleep period."
+          },
+          "ring_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ring Id",
+            "description": "Encrypted identifier of the ring that produced this sleep data."
+          },
+          "app_sleep_phase_5_min": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "App Sleep Phase 5 Min",
+            "description": "\n        5-minute sleep phase classification for the period aligned with what is shown in the app\n        where every character corresponds to:\n        '1' = deep sleep,\n        '2' = light sleep,\n        '3' = REM sleep\n        '4' = awake.\n        Example: \"444423323441114\".\n        NOTE: This field will be removed in the future after a transition period.\n        "
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "bedtime_end",
+          "bedtime_start",
+          "day",
+          "low_battery_alert",
+          "period",
+          "time_in_bed"
+        ],
+        "title": "PublicModifiedSleepModel",
+        "x-cloud-only": true,
+        "x-collection": "publicsleepmodel",
+        "x-owner": "sleep-squad"
+      },
+      "PublicMomentMood": {
+        "type": "string",
+        "enum": [
+          "bad",
+          "worse",
+          "same",
+          "good",
+          "great"
+        ],
+        "title": "PublicMomentMood",
+        "description": "Possible Moment moods."
+      },
+      "PublicMomentType": {
+        "type": "string",
+        "enum": [
+          "breathing",
+          "meditation",
+          "nap",
+          "relaxation",
+          "rest",
+          "body_status"
+        ],
+        "title": "PublicMomentType",
+        "description": "Possible Moment types."
+      },
+      "PublicReadiness": {
+        "properties": {
+          "contributors": {
+            "$ref": "#/components/schemas/PublicReadinessContributors",
+            "title": "",
+            "description": "Contributors of the readiness score."
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Readiness score in range [1, 100]."
+          },
+          "temperature_deviation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Temperature deviation in degrees Celsius."
+          },
+          "temperature_trend_deviation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Temperature trend deviation in degrees Celsius."
+          }
+        },
+        "type": "object",
+        "required": [
+          "contributors"
+        ],
+        "title": "PublicReadiness",
+        "description": "Object defining readiness."
+      },
+      "PublicReadinessContributors": {
+        "properties": {
+          "activity_balance": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of cumulative activity balance in range [1, 100]."
+          },
+          "body_temperature": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of body temperature in range [1, 100]."
+          },
+          "hrv_balance": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of heart rate variability balance in range [1, 100]."
+          },
+          "previous_day_activity": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of previous day's activity in range [1, 100]."
+          },
+          "previous_night": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of previous night's sleep in range [1, 100]."
+          },
+          "recovery_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of recovery index in range [1, 100]."
+          },
+          "resting_heart_rate": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of resting heart rate in range [1, 100]."
+          },
+          "sleep_balance": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of sleep balance in range [1, 100]."
+          },
+          "sleep_regularity": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of sleep regularity in range [1, 100]."
+          }
+        },
+        "type": "object",
+        "title": "PublicReadinessContributors",
+        "description": "Object defining readiness score contributors."
+      },
+      "PublicRestModeEpisode": {
+        "properties": {
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "",
+            "description": "Tags selected for the episode."
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Timestamp indicating when the episode occurred."
+          }
+        },
+        "type": "object",
+        "required": [
+          "tags",
+          "timestamp"
+        ],
+        "title": "PublicRestModeEpisode",
+        "description": "Object defining a public Rest Mode episode."
+      },
+      "PublicRestModePeriod": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "end_day": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ISODate"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "End date of rest mode."
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LocalizedDateTime"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Timestamp when rest mode ended."
+          },
+          "episodes": {
+            "items": {
+              "$ref": "#/components/schemas/PublicRestModeEpisode"
+            },
+            "type": "array",
+            "title": "",
+            "description": "Collection of episodes during rest mode, consisting of tags."
+          },
+          "start_day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "Start date of rest mode."
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LocalizedDateTime"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Timestamp when rest mode ended."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "episodes",
+          "start_day"
+        ],
+        "title": "PublicRestModePeriod",
+        "description": "Rest mode episode information.",
+        "x-cloud-only": true,
+        "x-collection": "publicrestmodeperiod",
+        "x-owner": "sleep-squad"
+      },
+      "PublicRingBatteryLevelRow": {
+        "properties": {
+          "timestamp": {
+            "$ref": "#/components/schemas/UtcDateTime",
+            "title": "",
+            "description": "Timestamp of the discrete sample."
+          },
+          "timestamp_unix": {
+            "type": "integer",
+            "title": "",
+            "description": "Timestamp of the discrete sample as unix time in milliseconds."
+          },
+          "charging": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Flag indicating if the ring was charging."
+          },
+          "in_charger": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Flag indicating if the ring was in charger."
+          },
+          "level": {
+            "type": "integer",
+            "title": "",
+            "description": "Ring battery level percentage. These values are within [0, 100]."
+          }
+        },
+        "type": "object",
+        "required": [
+          "timestamp",
+          "timestamp_unix",
+          "level"
+        ],
+        "title": "PublicRingBatteryLevelRow",
+        "description": "Object defining a ring battery level event.",
+        "x-cloud-only": true,
+        "x-collection": "publicringbatterylevel",
+        "x-owner": "connectivity-squad"
+      },
+      "PublicRingColor": {
+        "type": "string",
+        "enum": [
+          "brushed_silver",
+          "glossy_black",
+          "glossy_gold",
+          "glossy_white",
+          "gucci",
+          "matt_gold",
+          "rose",
+          "silver",
+          "stealth_black",
+          "titanium",
+          "titanium_and_gold",
+          "cloud",
+          "petal",
+          "midnight",
+          "tide",
+          "deep_rose"
+        ],
+        "title": "PublicRingColor",
+        "description": "Possible ring colors."
+      },
+      "PublicRingConfiguration": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "color": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicRingColor"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Color of the ring."
+          },
+          "design": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicRingDesign"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Design of the ring."
+          },
+          "firmware_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Firmware version of the ring."
+          },
+          "hardware_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicRingHardwareType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Hardware type of the ring."
+          },
+          "set_up_at": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UtcDateTime"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "UTC timestamp indicating when the ring was set up."
+          },
+          "size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "US size of the ring."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "PublicRingConfiguration",
+        "description": "Ring configuration.",
+        "x-cloud-only": true,
+        "x-collection": "publicringconfiguration",
+        "x-owner": "connectivity-squad"
+      },
+      "PublicRingDesign": {
+        "type": "string",
+        "enum": [
+          "heritage",
+          "balance",
+          "balance_diamond",
+          "horizon",
+          "ceramic"
+        ],
+        "title": "PublicRingDesign",
+        "description": "Possible ring designs."
+      },
+      "PublicRingHardwareType": {
+        "type": "string",
+        "enum": [
+          "gen1",
+          "gen2",
+          "gen2m",
+          "gen3",
+          "gen4",
+          "or5"
+        ],
+        "title": "PublicRingHardwareType",
+        "description": "Possible ring hardware types."
+      },
+      "PublicSample": {
+        "properties": {
+          "interval": {
+            "type": "number",
+            "title": "",
+            "description": "Interval in seconds between the sampled items."
+          },
+          "items": {
+            "$ref": "#/components/schemas/Array_Union_float__NoneType__Bits64_",
+            "title": "",
+            "description": "Recorded sample items."
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Timestamp when the sample recording started."
+          }
+        },
+        "type": "object",
+        "required": [
+          "interval",
+          "items",
+          "timestamp"
+        ],
+        "title": "PublicSample",
+        "description": "Object defining a recorded sample."
+      },
+      "PublicSession": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "The date when the session occurred."
+          },
+          "end_datetime": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Timestamp indicating when the Moment ended."
+          },
+          "heart_rate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSample"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Recorded heart rate samples during the Moment."
+          },
+          "heart_rate_variability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSample"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Recorded heart rate variability samples during the Moment."
+          },
+          "mood": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicMomentMood"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "User-selected mood for the Moment."
+          },
+          "motion_count": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSample"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Recorded motion count samples during the Moment."
+          },
+          "start_datetime": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Timestamp indicating when the Moment started."
+          },
+          "type": {
+            "$ref": "#/components/schemas/PublicMomentType",
+            "title": "",
+            "description": "Type of the Moment."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "day",
+          "end_datetime",
+          "start_datetime",
+          "type"
+        ],
+        "title": "PublicSession",
+        "description": "Public model defining a recorded Session.",
+        "x-cloud-only": true,
+        "x-collection": "publicsession",
+        "x-owner": "wellbeing-squad"
+      },
+      "PublicSleepAlgorithmVersion": {
+        "type": "string",
+        "enum": [
+          "v1",
+          "v2"
+        ],
+        "title": "PublicSleepAlgorithmVersion",
+        "description": "Oura Sleep Staging Algorithms.\nv1 = original aka legacy aka OSSA 1.0,\nv2 = latest sleep algorithm"
+      },
+      "PublicSleepAnalysisReason": {
+        "type": "string",
+        "enum": [
+          "foreground_sleep_analysis",
+          "bedtime_edit",
+          "background_sleep_analysis",
+          "background_created_foreground_updated"
+        ],
+        "title": "PublicSleepAnalysisReason",
+        "description": "Possible sleep analysis reasons."
+      },
+      "PublicSleepContributors": {
+        "properties": {
+          "deep_sleep": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of deep sleep in range [1, 100]."
+          },
+          "efficiency": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of sleep efficiency in range [1, 100]."
+          },
+          "latency": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of sleep latency in range [1, 100]."
+          },
+          "rem_sleep": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of REM sleep in range [1, 100]."
+          },
+          "restfulness": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of sleep restfulness in range [1, 100]."
+          },
+          "timing": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of sleep timing in range [1, 100]."
+          },
+          "total_sleep": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Contribution of total sleep in range [1, 100]."
+          }
+        },
+        "type": "object",
+        "title": "PublicSleepContributors",
+        "description": "Object defining sleep score contributors."
+      },
+      "PublicSleepTime": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "Corresponding day for the sleep time."
+          },
+          "optimal_bedtime": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSleepTimeWindow"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Optimal bedtime."
+          },
+          "recommendation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSleepTimeRecommendation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Recommended action for bedtime."
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PublicSleepTimeStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Sleep time status; used to inform sleep time recommendation."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "day"
+        ],
+        "title": "PublicSleepTime",
+        "description": "Suggested bedtime for the user.",
+        "x-cloud-only": true,
+        "x-collection": "publicsleeptime",
+        "x-owner": "sleep-squad"
+      },
+      "PublicSleepTimeRecommendation": {
+        "type": "string",
+        "enum": [
+          "improve_efficiency",
+          "earlier_bedtime",
+          "later_bedtime",
+          "earlier_wake_up_time",
+          "later_wake_up_time",
+          "follow_optimal_bedtime"
+        ],
+        "title": "PublicSleepTimeRecommendation",
+        "description": "Possible public SleepTime recommendation."
+      },
+      "PublicSleepTimeStatus": {
+        "type": "string",
+        "enum": [
+          "not_enough_nights",
+          "not_enough_recent_nights",
+          "bad_sleep_quality",
+          "only_recommended_found",
+          "optimal_found"
+        ],
+        "title": "PublicSleepTimeStatus",
+        "description": "Possible public SleepTime status."
+      },
+      "PublicSleepTimeWindow": {
+        "properties": {
+          "day_tz": {
+            "type": "integer",
+            "title": "",
+            "description": "Timezone offset in second from GMT of the day"
+          },
+          "end_offset": {
+            "type": "integer",
+            "title": "",
+            "description": "End offset from midnight in second"
+          },
+          "start_offset": {
+            "type": "integer",
+            "title": "",
+            "description": "Start offset from midnight in second"
+          }
+        },
+        "type": "object",
+        "required": [
+          "day_tz",
+          "end_offset",
+          "start_offset"
+        ],
+        "title": "PublicSleepTimeWindow",
+        "description": "Object defining sleep time window"
+      },
+      "PublicSleepType": {
+        "type": "string",
+        "enum": [
+          "deleted",
+          "sleep",
+          "long_sleep",
+          "late_nap",
+          "rest"
+        ],
+        "title": "PublicSleepType",
+        "description": "Possible sleep period types.\n'deleted' = deleted sleep by user.\n'sleep' = user confirmed sleep / nap, min 15 minutes, max 3 hours, contributes to daily scores\n'late_nap' = user confirmed sleep / nap, min 15 minutes, ended after sleep day change (6 pm), contributes to next days daily scores\n'long_sleep' = sleep that is long enough (>3h) to automatically contribute to daily scores\n'rest' = Falsely detected sleep / nap, rejected in confirm prompt by user"
+      },
+      "PublicSpo2AggregatedValues": {
+        "properties": {
+          "average": {
+            "type": "number",
+            "title": "",
+            "description": "Average of spo2."
+          }
+        },
+        "type": "object",
+        "required": [
+          "average"
+        ],
+        "title": "PublicSpo2AggregatedValues",
+        "description": "Object defining public spo2 aggregated values."
+      },
+      "PublicVO2Max": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "Day that the estimate belongs to."
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Timestamp indicating when the estimate was created."
+          },
+          "vo2_max": {
+            "type": "integer",
+            "title": "",
+            "description": "VO2 max value."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "day",
+          "timestamp",
+          "vo2_max"
+        ],
+        "title": "PublicVO2Max",
+        "description": "VO2Max estimate.",
+        "x-cloud-only": true,
+        "x-collection": "publicvo2max",
+        "x-owner": "movement-squad"
+      },
+      "PublicWorkout": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "",
+            "description": "Unique identifier of the object."
+          },
+          "activity": {
+            "type": "string",
+            "title": "",
+            "description": "Type of the workout activity."
+          },
+          "calories": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Energy burned in kilocalories during the workout."
+          },
+          "day": {
+            "$ref": "#/components/schemas/ISODate",
+            "title": "",
+            "description": "Day when the workout occurred."
+          },
+          "distance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "Distance traveled in meters during the workout."
+          },
+          "end_datetime": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Timestamp indicating when the workout ended."
+          },
+          "intensity": {
+            "$ref": "#/components/schemas/PublicWorkoutIntensity",
+            "title": "",
+            "description": "Intensity of the workout."
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "",
+            "description": "User-defined label for the workout."
+          },
+          "source": {
+            "$ref": "#/components/schemas/PublicWorkoutSource",
+            "title": "",
+            "description": "Possible workout sources."
+          },
+          "start_datetime": {
+            "$ref": "#/components/schemas/LocalizedDateTime",
+            "title": "",
+            "description": "Timestamp indicating when the workout started."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "activity",
+          "day",
+          "end_datetime",
+          "intensity",
+          "source",
+          "start_datetime"
+        ],
+        "title": "PublicWorkout",
+        "description": "Public model for Workout.",
+        "x-cloud-only": true,
+        "x-collection": "publicworkout",
+        "x-owner": "movement-squad"
+      },
+      "PublicWorkoutIntensity": {
+        "type": "string",
+        "enum": [
+          "easy",
+          "moderate",
+          "hard"
+        ],
+        "title": "PublicWorkoutIntensity",
+        "description": "Possible workout intensities."
+      },
+      "PublicWorkoutSource": {
+        "type": "string",
+        "enum": [
+          "manual",
+          "autodetected",
+          "confirmed",
+          "workout_heart_rate"
+        ],
+        "title": "PublicWorkoutSource",
+        "description": "Possible workout sources."
+      },
+      "ResilienceContributors": {
+        "properties": {
+          "sleep_recovery": {
+            "type": "number",
+            "title": "Sleep Recovery",
+            "description": "Sleep recovery contributor to the resilience score. Range: [0, 100]"
+          },
+          "daytime_recovery": {
+            "type": "number",
+            "title": "Daytime Recovery",
+            "description": "Daytime recovery contributor to the resilience score. Range: [0, 100]"
+          },
+          "stress": {
+            "type": "number",
+            "title": "Stress",
+            "description": "Stress contributor to the resilience score. Range: [0, 100]"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sleep_recovery",
+          "daytime_recovery",
+          "stress"
+        ],
+        "title": "ResilienceContributors"
+      },
+      "TagModel": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "day": {
+            "type": "string",
+            "format": "date",
+            "title": "Day",
+            "description": "Day that the note belongs to."
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text",
+            "description": "Textual contents of the note."
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/LocalDateTime",
+            "description": "Timestamp of the note."
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags",
+            "description": "Selected tags for the tag."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "day",
+          "text",
+          "timestamp",
+          "tags"
+        ],
+        "title": "TagModel",
+        "description": "A TagModel maps to an ASSANote. An ASSANote in ExtAPIV2 is called a Tag\nA TagModel will be populated by data from an ASSANote\nThe fields in the TagModel map to fields in an ASSANote"
+      },
+      "TimeSeriesResponseDict": {
+        "properties": {
+          "data": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "TimeSeriesResponseDict"
+      },
+      "TimeSeriesResponse_PublicHeartRateRow_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicHeartRateRow"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "TimeSeriesResponse[PublicHeartRateRow]"
+      },
+      "TimeSeriesResponse_PublicRingBatteryLevelRow_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicRingBatteryLevelRow"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "next_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "TimeSeriesResponse[PublicRingBatteryLevelRow]"
+      },
+      "UpdateWebhookSubscriptionRequest": {
+        "properties": {
+          "verification_token": {
+            "type": "string",
+            "title": "Verification Token"
+          },
+          "callback_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Callback Url"
+          },
+          "event_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WebhookOperation"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "data_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ExtApiV2DataType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "verification_token"
+        ],
+        "title": "UpdateWebhookSubscriptionRequest"
+      },
+      "UtcDateTime": {
+        "type": "string"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WebhookOperation": {
+        "type": "string",
+        "enum": [
+          "create",
+          "update",
+          "delete"
+        ],
+        "title": "WebhookOperation"
+      },
+      "WebhookSubscriptionModel": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid4",
+            "title": "Id"
+          },
+          "callback_url": {
+            "type": "string",
+            "title": "Callback Url"
+          },
+          "event_type": {
+            "$ref": "#/components/schemas/WebhookOperation"
+          },
+          "data_type": {
+            "$ref": "#/components/schemas/ExtApiV2DataType"
+          },
+          "expiration_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expiration Time"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "callback_url",
+          "event_type",
+          "data_type",
+          "expiration_time"
+        ],
+        "title": "WebhookSubscriptionModel"
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://cloud.ouraring.com/oauth/authorize",
+            "tokenUrl": "https://api.ouraring.com/oauth/token",
+            "scopes": {
+              "email": "Email address of the user",
+              "personal": "Personal information (gender, age, height, weight)",
+              "daily": "Daily summaries of sleep, activity and readiness",
+              "heartrate": "Time series heart rate for Gen 3 users",
+              "workout": "Summaries for auto-detected and user entered workouts",
+              "tag": "User entered tags",
+              "session": "Guided and unguided sessions in the Oura app",
+              "spo2Daily": "SpO2 Average recorded during sleep"
+            }
+          }
+        }
+      },
+      "ClientIdAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-client-id",
+        "description": "Client ID for webhook subscription endpoints. Must be used together with x-client-secret header."
+      },
+      "ClientSecretAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-client-secret",
+        "description": "Client Secret for webhook subscription endpoints. Must be used together with x-client-id header."
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Data Model & Concepts",
+      "description": "## Core Concepts\nThe Oura API provides access to various types of health data collected by the Oura Ring. Understanding how this data is organized is essential for effective API usage.\n### Data Types Overview\n- **Daily Summaries**: Aggregated metrics for each day (sleep score, readiness score, activity score)\n- **Time Series Data**: Detailed measurements taken throughout the day (heart rate, HRV, temperature)\n- **Events**: Discrete occurrences such as workouts, tags, and sessions\n### Data Processing Timeline\n1. **Data Collection**: The Oura Ring continuously collects biometric data\n2. **Syncing**: Data transfers to the Oura cloud when users sync their ring via the mobile app\n3. **Processing**: Algorithms analyze raw data to generate insights and scores\n4. **API Availability**: Processed data becomes available through API endpoints\n### Data Syncing Behavior\nDifferent data types follow different syncing patterns:\n- **User-Initiated Sync Data**:\n  - **Sleep Data**: Only syncs when the user opens the Oura app and actively syncs their ring\n  - **Sleep Time Recommendations**: Updated after sleep data syncs\n  - **Readiness**: Calculated after sleep data is processed\n- **Background Sync Data**:\n  - **Daily Activity**: Updates periodically in the background\n  - **Daily Stress**: Updates periodically in the background\n  - **Heart Rate**: Updates periodically in the background\nThis difference in syncing behavior affects when data becomes available through the API. For the most reliable access to all data types, we strongly recommend implementing webhooks to receive notifications when new data is available.\n### Common Data Structures\n- **Timestamps**: All time-based data uses ISO 8601 format\n- **Scores**: Range from 0-100, with higher values indicating better performance\n- **Durations**: Provided in seconds unless otherwise specified\n- **IDs**: Unique identifiers for specific data objects follow a consistent format\n### Data Freshness\nThe Oura API provides the most recently synced data, which depends on when users last synced their ring. For real-time updates, consider using webhooks to receive notifications when new data becomes available.\n### Best Practices for Data Access\n- **Initial Load**: When a user first connects to your application, make a single request for historical data\n- **Ongoing Updates**: Use webhooks for all subsequent data updates\n- **Webhook Integration**: This approach minimizes API calls and ensures you always have the latest data\n- **Error Handling**: Be prepared for occasional gaps in data if users don't regularly sync their rings\n### API Version Information\nThe current Oura API (V2) is the only available integration point. The previous V1 API has been sunset and is no longer available.\n"
+    },
+    {
+      "name": "Code Examples",
+      "description": "Below are end-to-end examples showing how to use the Oura API in different programming languages:\n## OAuth2 Authentication Flow\n### Python\n```python\nimport requests\nimport json\nfrom urllib.parse import urlencode\nimport webbrowser\n\n# Your OAuth2 application credentials\nCLIENT_ID = \"YOUR_CLIENT_ID\"\nCLIENT_SECRET = \"YOUR_CLIENT_SECRET\"\nREDIRECT_URI = \"YOUR_REDIRECT_URI\"\n\n# Step 1: Direct user to authorization page\nauth_params = {\n    \"client_id\": CLIENT_ID,\n    \"redirect_uri\": REDIRECT_URI,\n    \"response_type\": \"code\",\n    \"scope\": \"daily heartrate personal\"\n}\nauth_url = f\"https://cloud.ouraring.com/oauth/authorize?{urlencode(auth_params)}\"\nprint(f\"Please visit this URL to authorize: {auth_url}\")\nwebbrowser.open(auth_url)\n\n# Step 2: Exchange authorization code for access token\n# After user authorizes, they'll be redirected to your redirect URI with a code parameter\nauth_code = input(\"Enter the authorization code from the redirect URL: \")\n\ntoken_url = \"https://api.ouraring.com/oauth/token\"\ntoken_data = {\n    \"grant_type\": \"authorization_code\",\n    \"code\": auth_code,\n    \"client_id\": CLIENT_ID,\n    \"client_secret\": CLIENT_SECRET,\n    \"redirect_uri\": REDIRECT_URI\n}\nresponse = requests.post(token_url, data=token_data)\ntokens = response.json()\naccess_token = tokens[\"access_token\"]\nrefresh_token = tokens[\"refresh_token\"]\n\n# Step 3: Use the access token to make API calls\nheaders = {\"Authorization\": f\"Bearer {access_token}\"}\nsleep_data = requests.get(\n    \"https://api.ouraring.com/v2/usercollection/sleep\",\n    headers=headers,\n    params={\"start_date\": \"2023-01-01\", \"end_date\": \"2023-01-07\"}\n)\nprint(json.dumps(sleep_data.json(), indent=2))\n\n# Step 4: Refresh the token when it expires\ndef refresh_access_token(refresh_token):\n    token_data = {\n        \"grant_type\": \"refresh_token\",\n        \"refresh_token\": refresh_token,\n        \"client_id\": CLIENT_ID,\n        \"client_secret\": CLIENT_SECRET\n    }\n    response = requests.post(token_url, data=token_data)\n    new_tokens = response.json()\n    return new_tokens[\"access_token\"], new_tokens[\"refresh_token\"]\n```\n### JavaScript\n```javascript\n// Step 1: Redirect to authorization page\nconst authorizeUser = () => {\n  const CLIENT_ID = \"YOUR_CLIENT_ID\";\n  const REDIRECT_URI = \"YOUR_REDIRECT_URI\";\n  const scopes = [\"daily\", \"heartrate\", \"personal\"];\n\n  const authUrl = `https://cloud.ouraring.com/oauth/authorize?` +\n    `client_id=${CLIENT_ID}&` +\n    `redirect_uri=${encodeURIComponent(REDIRECT_URI)}&` +\n    `response_type=code&` +\n    `scope=${scopes.join(\" \")}`;\n\n  // Redirect user to authorization page\n  window.location.href = authUrl;\n};\n\n// Step 2: Exchange authorization code for access token\n// This should be implemented on your server to protect your client secret\nasync function getAccessToken(code) {\n  const response = await fetch(\"https://api.ouraring.com/oauth/token\", {\n    method: \"POST\",\n    headers: {\n      \"Content-Type\": \"application/x-www-form-urlencoded\",\n    },\n    body: new URLSearchParams({\n      grant_type: \"authorization_code\",\n      code: code,\n      client_id: \"YOUR_CLIENT_ID\",\n      client_secret: \"YOUR_CLIENT_SECRET\",\n      redirect_uri: \"YOUR_REDIRECT_URI\"\n    })\n  });\n\n  const tokens = await response.json();\n  return tokens;\n}\n\n// Step 3: Make API calls\nasync function fetchSleepData(accessToken) {\n  const startDate = \"2023-01-01\";\n  const endDate = \"2023-01-07\";\n\n  const response = await fetch(\n    `https://api.ouraring.com/v2/usercollection/sleep?start_date=${startDate}&end_date=${endDate}`,\n    {\n      headers: {\n        Authorization: `Bearer ${accessToken}`\n      }\n    }\n  );\n\n  return await response.json();\n}\n```\n## Working with Webhooks\n### NodeJS Express Server Example\n```javascript\nconst express = require('express');\nconst bodyParser = require('body-parser');\nconst crypto = require('crypto');\n\nconst app = express();\napp.use(bodyParser.json());\n\nconst CLIENT_SECRET = \"YOUR_CLIENT_SECRET\";\n\n// Verification endpoint for webhook setup\napp.get('/oura-webhook', (req, res) => {\n  const { verification_token, challenge } = req.query;\n\n  // Verify the token matches what you expect\n  if (verification_token === \"YOUR_VERIFICATION_TOKEN\") {\n    res.json({ challenge });\n  } else {\n    res.status(401).send('Invalid verification token');\n  }\n});\n\n// Webhook handler for incoming data\napp.post('/oura-webhook', (req, res) => {\n  const signature = req.headers['x-oura-signature'];\n  const timestamp = req.headers['x-oura-timestamp'];\n\n  // Verify HMAC signature for security\n  const hmac = crypto.createHmac('sha256', CLIENT_SECRET);\n  hmac.update(timestamp + JSON.stringify(req.body));\n  const calculatedSignature = hmac.digest('hex').toUpperCase();\n\n  if (calculatedSignature !== signature) {\n    return res.status(401).send('Invalid signature');\n  }\n\n  // Process the webhook data\n  const { event_type, data_type, object_id, user_id } = req.body;\n\n  console.log(`Received ${event_type} event for ${data_type}`);\n\n  // Fetch the updated data using the object_id\n  // This should be done asynchronously to respond quickly\n  fetchDataAsync(data_type, object_id, user_id);\n\n  // Respond quickly to acknowledge receipt\n  res.status(200).send('OK');\n});\n\napp.listen(3000, () => {\n  console.log('Webhook server listening on port 3000');\n});\n\n// Asynchronous function to fetch the updated data\nasync function fetchDataAsync(dataType, objectId, userId) {\n  // Implementation depends on your data storage and processing needs\n  // This would typically fetch the new data from the Oura API\n  // and update your database or application state\n}\n```\n"
+    },
+    {
+      "name": "Frequently Asked Questions",
+      "description": "## General Questions\n### What is the Oura API used for?\nThe Oura API allows developers to access Oura Ring data programmatically. This enables building applications, conducting research, or personal projects that use sleep, activity, readiness, and other health metrics collected by the Oura Ring.\n### How do I get started with the Oura API?\n1. Register an [OAuth application](https://cloud.ouraring.com/oauth/applications)\n2. Read the documentation and explore the available endpoints\n3. Make your first API call using the examples provided\n### What data types are available in the API?\nThe Oura API provides access to various data types including:\n- Sleep metrics and stages\n- Activity and movement data\n- Readiness scores and contributors\n- Heart rate and HRV measurements\n- Workout information\n- Tags and sessions\n- And more specialized metrics like SpO2, body temperature, and stress levels\n### Is the Oura API free to use?\nYes, the Oura API is free to use for both personal and commercial applications. However, API applications accessing more than 10 users require approval from Oura.\n## Technical Questions\n### What's the recommended way to consume Oura data?\nWebhooks are the preferred way to consume Oura data. We recommend:\n1. Make a single request for historical data when a user first connects to your application\n2. Set up webhook subscriptions for all data types you need\n3. Use webhook notifications to get updates as new data becomes available\nThis approach is efficient and we have not had customers hit rate limits with webhooks properly implemented.\n### How do I handle rate limits?\nThe Oura API is limited to 5000 requests per 5-minute period. To avoid hitting rate limits:\n- Use webhooks instead of polling (strongly recommended - we have not seen any customers hit rate limits with webhooks properly implemented)\n- Cache responses when appropriate\n- Batch requests for multiple days of data rather than individual day requests\n- Implement exponential backoff when you receive a 429 response\n### Why am I not seeing today's data?\nOura Ring data availability depends on the data type:\n- **Sleep, Readiness, and Sleep Time data**: Only available after the user opens the Oura app and syncs their ring\n- **Daily Activity, Daily Stress, and Heart Rate**: May update periodically in the background\nFor the most reliable access to all data types, implement webhooks to receive notifications when new data is available (approximately 30 seconds after the data syncs from the mobile app).\n### How do I handle timezone differences?\nAll timestamps in the Oura API use ISO 8601 format with timezone information. When querying data with date parameters, the dates are interpreted in the user's local timezone. Make sure to account for this when processing data across different timezones.\n### What API version should I use?\nThe current Oura API (V2) is the only available integration point. The previous V1 API has been sunset and is no longer available.\n### How do webhooks work with the Oura API?\nWebhooks allow you to receive near real-time notifications when new data is available, rather than constantly polling the API. You'll need to:\n1. Set up an endpoint on your server to receive webhook events\n2. Create webhook subscriptions for each data type and event type you're interested in\n3. Verify your endpoint when creating subscriptions\n4. Process webhook events as they arrive\n5. Fetch the full data using the provided IDs\nWebhook notifications arrive approximately 30 seconds after data syncs from the mobile app.\n## Troubleshooting\n### I'm getting 401 Unauthorized errors\nThis typically means your access token is invalid or expired. Check that:\n- You're including the token correctly in the Authorization header\n- The token hasn't expired (they typically last 30 days)\n- The user hasn't revoked access\n- For OAuth2 applications, try refreshing the token\n### I'm getting 403 Forbidden errors\nThis usually means the user's Oura subscription has expired or they haven't granted permission for the specific data type you're requesting.\n### Why am I not receiving webhook events?\nEnsure that:\n- Your webhook endpoint is publicly accessible\n- The endpoint responds to the verification challenge correctly\n- Your endpoint responds within 10 seconds with a 2xx or 3xx status code\n- You've subscribed to the correct data types and event types\n- The user has synced their ring recently to generate new data\n### How can I validate that a webhook is legitimate?\nAlways verify the HMAC signature included in the x-oura-signature header using your client secret as shown in the webhook code examples.\n## Best Practices\n### What's the best approach for accessing historical data?\nWe recommend:\n1. When a user first connects to your application, make a single request for historical data\n2. For ongoing updates, use webhooks instead of repeated API calls\n3. Store the historical data in your own database for easy access\n4. Only fetch new or updated data based on webhook notifications\nThis approach minimizes API calls and ensures your application always has the latest data without hitting rate limits.\n### How should I handle missing data?\nSome users may have gaps in their data if they didn't wear their ring or haven't synced it recently. Your application should:\n- Check for null values in responses\n- Have fallback logic for missing data points\n- Consider displaying gaps in visualizations rather than connecting across missing data\n- Use webhooks to ensure you're promptly notified when new data becomes available\n### What's the best way to get historical data?\nTo efficiently retrieve a large amount of historical data:\n1. Use date range queries with reasonable time spans (e.g., 1-3 months at a time)\n2. Implement pagination using the next_token parameter for large result sets\n3. Consider running historical data collection as a background job\n4. Store the data in your own database to avoid repeated API calls\n### How can I ensure user privacy?\n- Only request access to the data types your application needs\n- Store tokens securely and never expose them in client-side code\n- Implement proper security measures for storing health data\n- Be transparent with users about how their data will be used\n- Allow users to disconnect your application and delete their data\n"
+    },
+    {
+      "name": "Authentication Troubleshooting",
+      "description": "## Common Authentication Issues\n### \"401 Unauthorized\" Error\nThis is the most common authentication error and typically means there's an issue with your token. Here are the most frequent causes and solutions:\n#### 1. Invalid Token Format\n**Problem**: The token you're using isn't formatted correctly in the request.\n**Solution**: Ensure you're including \"Bearer\" before your token:\n```\nAuthorization: Bearer your-token-here\n```\n**Example Correct Implementation**:\n```javascript\n// JavaScript example\nfetch('https://api.ouraring.com/v2/usercollection/personal_info', {\n  headers: {\n    'Authorization': 'Bearer ' + accessToken  // Note the space after \"Bearer\"\n  }\n})\n```\n#### 2. Expired Token\n**Problem**: OAuth2 access tokens expire after a period (typically 24 hours for Oura).\n**Solution**: Use your refresh token to get a new access token:\n```http\nPOST https://api.ouraring.com/oauth/token\nContent-Type: application/x-www-form-urlencoded\n\ngrant_type=refresh_token&\nrefresh_token=YOUR_REFRESH_TOKEN&\nclient_id=YOUR_CLIENT_ID&\nclient_secret=YOUR_CLIENT_SECRET\n```\n\n**Handling Token Expiration**:\n```javascript\n// JavaScript example of handling expired tokens\nasync function callApi(endpoint, accessToken, refreshToken) {\n  try {\n    const response = await fetch(`https://api.ouraring.com/v2/${endpoint}`, {\n      headers: {\n        'Authorization': `Bearer ${accessToken}`\n      }\n    });\n\n    if (response.status === 401) {\n      // Token expired, try to refresh\n      const newTokens = await refreshAccessToken(refreshToken);\n\n      // Retry the request with the new token\n      return fetch(`https://api.ouraring.com/v2/${endpoint}`, {\n        headers: {\n          'Authorization': `Bearer ${newTokens.access_token}`\n        }\n      });\n    }\n\n    return response;\n  } catch (error) {\n    console.error('API call failed:', error);\n    throw error;\n  }\n}\n\nasync function refreshAccessToken(refreshToken) {\n  const response = await fetch('https://api.ouraring.com/oauth/token', {\n    method: 'POST',\n    headers: {\n      'Content-Type': 'application/x-www-form-urlencoded'\n    },\n    body: new URLSearchParams({\n      'grant_type': 'refresh_token',\n      'refresh_token': refreshToken,\n      'client_id': YOUR_CLIENT_ID,\n      'client_secret': YOUR_CLIENT_SECRET\n    })\n  });\n\n  return response.json();\n}\n```\n\n#### 3. Revoked Access\n**Problem**: The user has revoked access to your application.\n\n**Solution**: The user needs to re-authorize your application. Direct them to the authorization URL:\n```\nhttps://cloud.ouraring.com/oauth/authorize?\n  client_id=YOUR_CLIENT_ID&\n  redirect_uri=YOUR_REDIRECT_URI&\n  response_type=code&\n  scope=daily heartrate personal\n```\n### \"403 Forbidden\" Error\nThis error means your authentication is valid, but you don't have permission to access the requested resource.\n#### 1. Missing Scope Permission\n**Problem**: Your OAuth application doesn't have the necessary scope for the endpoint.\n**Solution**: Request the needed scopes during authorization:\n```\nhttps://cloud.ouraring.com/oauth/authorize?\n  client_id=YOUR_CLIENT_ID&\n  redirect_uri=YOUR_REDIRECT_URI&\n  response_type=code&\n  scope=daily heartrate personal workout session\n```\n**Available Scopes**:\n- `daily`: Daily summaries (sleep, activity, readiness)\n- `heartrate`: Heart rate data\n- `personal`: Personal information (age, gender, etc.)\n- `workout`: Workout data\n- `session`: Session data\n- `tag`: Tag data\n#### 2. Expired Oura Membership\n**Problem**: The user's Oura membership has expired.\n**Solution**: The user needs to renew their Oura membership to restore API access.\n### OAuth2 Flow Debugging\n#### Authorization Code Flow Issues\n**Problem**: Not receiving an authorization code after user consent.\n**Solutions**:\n1. Verify your redirect URI exactly matches what's registered in your application\n2. Check for errors in the redirect (look for `error` and `error_description` query parameters)\n3. Ensure the user is completing the consent process\n**Example Debugging**:\n```javascript\n// Parse the URL after redirect\nconst urlParams = new URLSearchParams(window.location.search);\nconst error = urlParams.get('error');\nconst errorDescription = urlParams.get('error_description');\n\nif (error) {\n  console.error(`Authorization failed: ${error} - ${errorDescription}`);\n} else {\n  const code = urlParams.get('code');\n  if (code) {\n    // Proceed with token exchange\n  } else {\n    console.error('No authorization code received in the redirect');\n  }\n}\n```\n#### Token Exchange Issues\n**Problem**: Error when exchanging authorization code for tokens.\n**Common Errors and Solutions**:\n- `invalid_grant`: The authorization code is expired (valid for only 10 minutes) or already used\n- `invalid_client`: Client ID or secret is incorrect\n- `invalid_redirect_uri`: Redirect URI doesn't match the one used during authorization\n**Testing Token Exchange**:\n```bash\n# Using curl to debug token exchange\ncurl -X POST https://api.ouraring.com/oauth/token   -d \"grant_type=authorization_code\"   -d \"code=YOUR_AUTH_CODE\"   -d \"client_id=YOUR_CLIENT_ID\"   -d \"client_secret=YOUR_CLIENT_SECRET\"   -d \"redirect_uri=YOUR_REDIRECT_URI\"\n```\n## Authentication Best Practices\n### Security Recommendations\n1. **Never store access tokens in client-side code** or expose them in URLs\n2. **Use HTTPS** for all communication with the Oura API\n3. **Store refresh tokens securely** (e.g., in an encrypted database)\n4. **Implement token rotation** to regularly refresh access tokens\n5. **Validate tokens** before using them if they've been stored for a while\n### Token Management\n1. **Create a token service** in your backend to handle token operations:\n   - Storing tokens securely\n   - Refreshing expired tokens\n   - Associating tokens with user accounts\n2. **Handle token revocation gracefully**:\n   - Detect when a token has been revoked\n   - Clear local token storage\n   - Prompt the user to re-authorize when needed\n3. **Implement proper error handling**:\n   - Distinguish between different types of auth errors\n   - Provide clear messages to users\n   - Log authentication issues for debugging\n"
+    },
+    {
+      "name": "Daily Activity Routes",
+      "description": "The Daily Activity scope includes daily activity summary values and detailed activity levels. Activity levels are expressed in [metabolic equivalent of task minutes](https://en.wikipedia.org/wiki/Metabolic_equivalent) (MET mins). Oura tracks activity based on the movement."
+    },
+    {
+      "name": "Daily Cardiovascular Age Routes",
+      "description": "Cardiovascular Age is an estimate of the health of your cardiovascular system in relation to your actual age. See more details [here](https://support.ouraring.com/hc/en-us/articles/28451491040019-Cardiovascular-Age)."
+    },
+    {
+      "name": "Daily Readiness Routes",
+      "description": "Readiness tells how ready you are for the day."
+    },
+    {
+      "name": "Daily Resilience Routes",
+      "description": "Resilience is an estimate of your ability to withstand physiological stress and recover from it over time.",
+      "externalDocs": {
+        "description": "Learn more about Resilience",
+        "url": "https://support.ouraring.com/hc/en-us/articles/25358829055251-Resilience"
+      }
+    },
+    {
+      "name": "Daily Sleep Routes",
+      "description": "Sleep period is a nearly continuous, longish period of time spent lying down in bed."
+    },
+    {
+      "name": "Daily Spo2 Routes",
+      "description": "The Daily SpO2 (blood oxygenation) routes include daily SpO2 average. Data will only be available for users with a Gen 3 Oura Ring",
+      "externalDocs": {
+        "description": "Blood Oxygen Sensing (SpO2) on Oura",
+        "url": "https://ouraring.com/blog/blood-oxygen-sensing-spo2"
+      }
+    },
+    {
+      "name": "Daily Stress Routes",
+      "description": "The daily stress route includes a summary of the number of minutes the user spends in high stress and high recovery each day. This is a great way to see how your stress and recovery are trending over time. Stress and recovery are mutally exclusive. E.g. one can only be stressed or recovered at any given moement - and cannot be stressed and recovered at the same time.",
+      "externalDocs": {
+        "description": "Learn more about daytime stress",
+        "url": "https://ouraring.com/blog/daytime-stress-feature"
+      }
+    },
+    {
+      "name": "Enhanced Tag Routes",
+      "description": "The Enhanced Tags data scope includes tags that Oura users enter within the Oura mobile app. Enhanced Tags can be added for any lifestyle choice, habit, mood change, or environmental factor an Oura user wants to monitor the effects of. Enhanced Tags also contain context on a tag's start and end time, whether a tag repeats daily, and comments.\n\n[Learn more about how Oura users add Enhanced Tags](https://support.ouraring.com/hc/en-us/articles/360038676993-How-to-Use-Tags)",
+      "externalDocs": {
+        "description": "More information about Enhanced Tags",
+        "url": "https://ouraring.com/blog/tags/"
+      }
+    },
+    {
+      "name": "Heart Rate Routes",
+      "description": "The Heart Rate data scope includes time-series heart rate data throughout the day and night. Heart rate is provided at 5-minute increments. For heart rate data recorded from a Session, see Sessions endpoint.",
+      "externalDocs": {
+        "description": "How accurate is the heart rate data generated by the Oura Ring?",
+        "url": "https://ouraring.com/blog/how-accurate-is-oura/"
+      }
+    },
+    {
+      "name": "Personal Info Routes",
+      "description": "The Personal Info scope includes personal information (e.g. age, email, weight, and height) about the user. You can access the id on the personal_info route with any access token (no scopes are required)."
+    },
+    {
+      "name": "Rest Mode Period Routes",
+      "description": "The Rest Mode scope includes information about rest mode periods. This includes the start, end time and detaials of the rest mode period."
+    },
+    {
+      "name": "Ring Configuration Routes",
+      "description": "The Ring Configuration scope includes information about the user's ring(s). This includes the model, size, color, etc."
+    },
+    {
+      "name": "Session Routes",
+      "description": "The Sessions data scope provides information on how users engage with guided and unguided sessions in the Oura app, including the user's biometric trends during the sessions.",
+      "externalDocs": {
+        "description": "Learn about the available session types within the Explore Tab",
+        "url": "https://ouraring.com/blog/oura-explore-tab/"
+      }
+    },
+    {
+      "name": "Sleep Routes",
+      "description": "Returns Oura Sleep data for the specified Oura user within a given timeframe. A user can have multiple sleep periods per day."
+    },
+    {
+      "name": "Sleep Time Routes",
+      "description": "Recommendations for the optimal bedtime window that is calculated based on sleep data."
+    },
+    {
+      "name": "Tag Routes",
+      "description": "<span className='text-important'>**Note:** Tag is deprecated. We recommend transitioning to [Enhanced Tag](#tag/Enhanced-Tag-Routes).</span>\n\n~~The Tags data scope includes tags that Oura users enter within the Oura mobile app. Tags are a growing list of activities, environment factors, symptoms, emotions, and other aspects that provide broader context into what's happening with users beyond the objective data generated by the Oura Ring.~~\n\n~~[More information on tag translations](https://cloud.ouraring.com/edu/tag-translations)~~"
+    },
+    {
+      "name": "VO2 Max Routes",
+      "description": "VO2 Max is a measure of the maximum volume of oxygen that an individual can use during intense exercise. See more details [here](https://support.ouraring.com/hc/en-us/articles/28336620578835-Cardio-Capacity-VO2-Max)."
+    },
+    {
+      "name": "Workout Routes",
+      "description": "The Workout data scope includes information about user workouts. This is a diverse, growing list of workouts that help inform how the user is training and exercising."
+    },
+    {
+      "name": "Sandbox Routes",
+      "description": "Fake user data that you can access without an Oura account. There is a corresponding sandbox endpoint to each available data type. This is useful for testing and development purposes. The data is not real and should not be used for any production purposes. The data is generated by Oura and is not based on any real user data. The data is not updated in real-time and is not guaranteed to be accurate. The rate limit for the sandbox endpoints is shared with your rate limit on other data endpoints."
+    },
+    {
+      "name": "Webhook Subscription Routes",
+      "description": "# Webhooks for Real-Time Data Updates\n\n## What are Webhooks?\nWebhooks are a way for the Oura API to notify your application when new data is available, instead of requiring your application to constantly check for updates (polling). Think of webhooks as \"reverse APIs\" - instead of your application requesting data, Oura's servers send data to your application when something changes.\n\n## Why Use Webhooks (Important!)\n- **RECOMMENDED APPROACH**: Webhooks are the preferred way to consume Oura data\n- **Avoid Rate Limits**: We have not had customers hit rate limits with webhooks properly implemented\n- **Near Real-Time Updates**: Webhook notifications come approximately 30 seconds after data syncs from the mobile app\n- **Efficient Resource Usage**: Reduces unnecessary API calls and server load\n- **Better User Experience**: Your application stays updated without constant polling\n\n## How Webhooks Work with Oura\n1. **You set up an endpoint**: Create a URL on your server that can receive POST requests\n2. **You subscribe to events**: Tell Oura what data types and events you want to be notified about\n3. **Oura verifies your endpoint**: A one-time check to ensure your endpoint is valid\n4. **Oura sends notifications**: When data changes, Oura sends a POST request to your endpoint\n5. **You process the event**: Your endpoint receives basic event details\n6. **You fetch complete data**: Use the provided IDs to retrieve the full data via the API\n\n## Recommended Implementation Pattern\n1. **Initial Data Load**: When a user first connects, make a single API request for historical data\n2. **Subscribe to Webhooks**: Set up webhook subscriptions for all data types you need\n3. **Process Webhook Events**: As users sync their rings, you'll receive notifications about new data\n4. **Fetch Updated Data**: Use the object_id from webhook events to fetch the specific updated data\n\nThis pattern minimizes API calls while ensuring your application always has the latest data.\n\n## Setup Guide\n\n### Step 1: Create Your Webhook Endpoint\nSet up an HTTP endpoint on your server that can:\n- Handle both GET requests (for verification) and POST requests (for events)\n- Respond to verification challenges during subscription setup\n- Process incoming webhook events quickly (under 10 seconds)\n\nExample endpoint implementation (Node.js):\n```javascript\n// Express.js route handlers for your webhook endpoint\napp.get('/oura-webhook', (req, res) => {\n  // Verification handler - required during subscription setup\n  const { verification_token, challenge } = req.query;\n\n  // Verify the token matches your expected token\n  if (verification_token === YOUR_VERIFICATION_TOKEN) {\n    // Return the challenge in the required format\n    return res.json({ challenge });\n  }\n\n  // If verification fails\n  return res.status(401).send('Invalid verification token');\n});\n\napp.post('/oura-webhook', (req, res) => {\n  // Event handler - processes incoming webhook events\n\n  // Always respond quickly (under 10 seconds)\n  // Process the event asynchronously if needed\n  res.status(200).send('OK');\n\n  // Then process the event data\n  const { event_type, data_type, object_id, user_id } = req.body;\n  processEventAsync(event_type, data_type, object_id, user_id);\n});\n```\n\n### Step 2: Create a Webhook Subscription\nCall the `POST /v2/webhook/subscription` endpoint to register your webhook:\n\n```\nPOST /v2/webhook/subscription\nHeaders:\n  x-client-id: YOUR_CLIENT_ID\n  x-client-secret: YOUR_CLIENT_SECRET\n  Content-Type: application/json\n\nBody:\n{\n  \"callback_url\": \"https://your-server.com/oura-webhook\",\n  \"verification_token\": \"your-secret-verification-token\",\n  \"event_type\": \"update\",\n  \"data_type\": \"sleep\"\n}\n```\n\nYou need to create separate subscriptions for each combination of:\n- **event_type**: The type of event (create, update, delete)\n- **data_type**: The type of data you're interested in (sleep, activity, etc.)\n\n### Step 3: Verification Process\nWhen you create a subscription, Oura verifies your endpoint:\n\n1. Oura sends a GET request to your callback URL with query parameters:\n   ```\n   GET https://your-server.com/oura-webhook?verification_token=your-token&challenge=random-string\n   ```\n\n2. Your endpoint must verify the token and respond with the challenge:\n   ```json\n   {\n     \"challenge\": \"random-string\"\n   }\n   ```\n\n3. If verification succeeds, your subscription is activated\n\n![Verification Flow](/img/webhook-verification-flow-diagram.drawio.png)\n\n### Step 4: Receiving and Processing Events\nWhen an event occurs (e.g., user syncs new sleep data):\n\n1. Oura sends a POST request to your callback URL:\n   ```\n   POST https://your-server.com/oura-webhook\n   Headers:\n     x-oura-signature: HMAC_SIGNATURE\n     x-oura-timestamp: 1234567890\n\n   Body:\n   {\n     \"event_type\": \"update\",\n     \"data_type\": \"sleep\",\n     \"object_id\": \"12345abc\",\n     \"event_time\": \"2023-01-01T08:00:00+00:00\",\n     \"user_id\": \"user123\"\n   }\n   ```\n\n2. Your endpoint should:\n   - Verify the signature for security (see below)\n   - Respond quickly (under 10 seconds) with a 2xx status\n   - Process the event asynchronously if needed\n   - Use the object_id to fetch the complete data via the API\n\n## Security Best Practices\n\n### Verify Webhook Signatures\nAlways verify that webhook requests are actually from Oura by checking the HMAC signature:\n\n```javascript\nconst crypto = require('crypto');\n\nfunction verifySignature(headers, body, clientSecret) {\n  const signature = headers['x-oura-signature'];\n  const timestamp = headers['x-oura-timestamp'];\n\n  // Create HMAC using your client secret\n  const hmac = crypto.createHmac('sha256', clientSecret);\n  hmac.update(timestamp + JSON.stringify(body));\n  const calculatedSignature = hmac.digest('hex').toUpperCase();\n\n  // Compare calculated signature with received signature\n  return calculatedSignature === signature;\n}\n\n// In your webhook handler\napp.post('/oura-webhook', (req, res) => {\n  // Verify signature\n  if (!verifySignature(req.headers, req.body, CLIENT_SECRET)) {\n    return res.status(401).send('Invalid signature');\n  }\n\n  // Process valid webhook\n  res.status(200).send('OK');\n  // ...\n});\n```\n\n### Use HTTPS\nAlways use HTTPS for your webhook endpoint to ensure data is encrypted in transit.\n\n### Keep Your Verification Token Secret\nChoose a strong, random verification token and don't share it.\n\n## Handling Webhook Failures\n\n### Retry Mechanism\nOura will retry failed webhook deliveries:\n- For 4xx responses: 10 retries\n- For 5xx responses: 10 retries\n- For timeouts: 10 retries\n\n### Canceling Subscriptions\nIf you want to cancel a subscription, you can:\n- Use the DELETE endpoint: `DELETE /v2/webhook/subscription/{id}`\n- Or respond with a 410 status code to automatically cancel\n\n## Common Questions\n\n### How quickly will I receive webhooks?\nWebhook notifications arrive approximately 30 seconds after data syncs from the mobile app. The timing depends on the data type:\n- **Sleep, Readiness, and other user-initiated sync data**: These only sync when the user opens the Oura app and actively syncs their ring\n- **Daily Activity, Daily Stress, and other background data**: These may update periodically in the background without user action\n\n### What if my server goes down?\nOura will retry webhook deliveries for about an hour if your server doesn't respond properly. However, if your server is down for an extended period, you might miss some events. It's a good practice to implement a reconciliation process that can fetch data for periods when your webhook might have been unavailable.\n\n### How can I test webhooks locally?\nUse a tool like [ngrok](https://ngrok.com/) to expose your local development server to the internet with a public URL.\n\n### Can I use the same callback URL for different subscriptions?\nYes, you can use the same URL for multiple subscriptions. Your handler can differentiate between events using the `event_type` and `data_type` fields in the webhook payload.\n\n### Will I hit rate limits using webhooks?\nWe have not had customers hit rate limits with webhooks properly implemented. The recommended pattern is:\n1. Make a single request for historical data when a user first connects\n2. Use webhooks for all ongoing data updates\n3. Only fetch the specific data that has changed based on webhook notifications\n\nThis approach minimizes API calls while ensuring your application always has the latest data.\n        "
+    }
+  ]
+}

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,4 +1,49 @@
-﻿# 🛠️ Oura Ring v2 Integration v2.8.1 - Current Heart Rate Freshness Fix
+﻿# 🎉 Oura Ring v2 Integration v2.8.2 - Oura API v1.35 + Bedtime Fix
+
+## ✨ NEW IN v2.8.2
+
+### Oura API v1.35 Support
+
+**New sensor: Sleep Analysis Reason** (`sleep_analysis_reason`)
+
+- Exposes how Oura detected your sleep session: `foreground_sleep_analysis` (app sync), `background_sleep_analysis` (Ring 5 passive detection), `bedtime_edit` (manually adjusted), or `background_created_foreground_updated`.
+- **Entity category**: Diagnostic.
+- **Ring 5 note**: Background sleep analysis (new in API 1.35) allows the Ring 5 to detect and record sleep without requiring an Oura app sync first.
+
+**Ring hardware type display names**
+
+- `or5` hardware type now correctly displays as **"Oura Ring 5"** (previously rendered as "Oura Ring Or5" due to a `.capitalize()` bug).
+- `gen4` now displays as **"Oura Ring 4"** (was "Oura Ring Gen4").
+- Gen 1–3 now display with proper spacing (e.g., "Oura Ring Gen 3").
+- All known hardware types are handled via a lookup dict (`RING_MODEL_NAMES` in `const.py`); unknown future types fall back gracefully.
+
+**New ring color: `deep_rose`**
+
+- Added to the Oura Ring color enum in API 1.35. No code changes required — ring colors are passed through dynamically and are not validated by the integration.
+
+## 🐛 BUG FIX IN v2.8.2
+
+### Bedtime End shows afternoon/evening value just after midnight
+
+- **Fixed**: `sensor.oura_ring_bedtime_end` momentarily showing an incorrect afternoon or evening time (e.g., 17:14, 21:04, 18:04) just after midnight (~00:00:30) before correcting itself hours later to the proper morning wake-up time.
+
+**Root cause**: Oura's `/sleep` API can return multiple completed sleep records for the same `day` — for example, the main overnight sleep (ending ≈08:30) alongside an afternoon nap or brief rest session (ending ≈17:00 or later). The coordinator sorts records by `day` to pick the most recent, but when two records share the same `day` value Python's stable sort preserves the original API response order. If the API returned the shorter nap record last, `[-1]` selected it — causing the wrong `bedtime_end` to display.
+
+**Fix**: Added `total_sleep_duration` as a secondary sort key. Within the same calendar day, the record with the **longest duration** (the overnight sleep) is now always sorted last and selected. A new test (`test_bedtime_prefers_longest_sleep_for_same_day`) verifies this behaviour.
+
+## 📊 ENTITY COUNT UPDATE
+
+- **Previous version**: 68 sensors + 2 binary sensors
+- **This version**: 69 sensors + 2 binary sensors (+1 Sleep Analysis Reason diagnostic sensor)
+
+## 🧪 TESTING & VALIDATION
+
+- ✅ 106 automated tests passing (106, up from 105)
+- ✅ New test: `test_bedtime_prefers_longest_sleep_for_same_day`
+
+---
+
+# 🛠️ Oura Ring v2 Integration v2.8.1 - Current Heart Rate Freshness Fix
 
 ## 🐛 BUG FIX IN v2.8.1
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -859,6 +859,39 @@ def test_process_sleep_details_ignores_records_older_than_2_days():
     assert processed.get("bedtime_end") == previous_end
 
 
+def test_bedtime_prefers_longest_sleep_for_same_day():
+    """When two long_sleep records share the same day, the longest (overnight) sleep wins."""
+    from datetime import datetime, timedelta, timezone
+
+    coordinator = MockCoordinator()
+    today = datetime.now(timezone.utc).date()
+    yesterday = (today - timedelta(days=1)).isoformat()
+
+    # Overnight sleep (~8h): started previous evening, ended this morning
+    overnight = {
+        "day": yesterday,
+        "type": "long_sleep",
+        "bedtime_start": f"{(today - timedelta(days=2)).isoformat()}T22:30:00+00:00",
+        "bedtime_end": f"{yesterday}T07:30:00+00:00",
+        "total_sleep_duration": 28800,  # 8 hours
+    }
+    # Same-day nap (~1h): started and ended on the same calendar day
+    nap = {
+        "day": yesterday,
+        "type": "long_sleep",
+        "bedtime_start": f"{yesterday}T15:00:00+00:00",
+        "bedtime_end": f"{yesterday}T16:00:00+00:00",
+        "total_sleep_duration": 3600,  # 1 hour
+    }
+    # API returns nap AFTER overnight — without duration sort, nap would be picked
+    data = {"sleep_detail": {"data": [overnight, nap]}}
+    processed = {}
+    coordinator._process_sleep_details(data, processed)
+
+    # Overnight sleep (longer duration) must win
+    assert processed["bedtime_end"] == datetime.fromisoformat(f"{yesterday}T07:30:00+00:00")
+
+
 def test_process_heart_rate_sorts_by_timestamp():
     """Out-of-order heart rate readings are sorted; most recent is current_heart_rate."""
     from datetime import datetime, timedelta, timezone

--- a/tests/test_ring_battery.py
+++ b/tests/test_ring_battery.py
@@ -332,10 +332,10 @@ class TestDeviceInfoEnrichment:
         return sensor
 
     def test_model_uses_hardware_type(self):
-        """device_info model is 'Oura Ring Gen4' when hardware_type=gen4."""
+        """device_info model maps hardware_type to a display name."""
         sensor = self._make_sensor_entity({"ring_hardware_type": "gen4", "ring_firmware_version": "2.8.10"})
         info = sensor.device_info
-        assert info["model"] == "Oura Ring Gen4"
+        assert info["model"] == "Oura Ring 4"
 
     def test_sw_version_uses_firmware_version(self):
         """device_info sw_version is set from ring firmware_version."""


### PR DESCRIPTION
## Summary

- **API v1.35 support**: new `sleep_analysis_reason` diagnostic sensor (exposes foreground/background sleep detection; Ring 5 now supports background detection), `or5` hardware type correctly displays as "Oura Ring 5", `gen4` as "Oura Ring 4", `deep_rose` ring color passes through dynamically
- **Bug fix**: `bedtime_end` showing afternoon/evening value just after midnight — fixed by adding `total_sleep_duration` as a secondary sort key so the longest (overnight) sleep always wins when multiple completed records share the same `day`
- **Version bump**: 2.8.1 → 2.8.2

## Test plan

- [x] 106 automated tests passing (`docker compose -f docker-compose.test.yml run --rm test`)
- [x] New test: `test_bedtime_prefers_longest_sleep_for_same_day` — verifies overnight sleep wins over same-day nap
- [x] Existing bedtime tests all pass
- [x] `test_model_uses_hardware_type` updated to expect "Oura Ring 4" (was "Oura Ring Gen4")

🤖 Generated with [Claude Code](https://claude.ai/claude-code)