### PR TITLE
feat: Expose the full day's workout list on the workouts_today sensor

### DIFF
--- a/custom_components/oura/coordinator.py
+++ b/custom_components/oura/coordinator.py
@@ -478,6 +478,7 @@ class OuraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     if self._parse_api_day(workout.get("day")) == today
                 ]
                 processed["workouts_today"] = len(today_workouts)
+                processed["_workouts_today_list"] = today_workouts
 
                 latest_workout = workout_data[-1]
                 processed["last_workout_type"] = latest_workout.get("activity")
@@ -497,6 +498,7 @@ class OuraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # No workout data in current API window — carry forward previous values
         processed["workouts_today"] = 0
+        processed["_workouts_today_list"] = []
         if self.data:
             for key in self._LAST_WORKOUT_KEYS:
                 if key in self.data:

--- a/custom_components/oura/sensor.py
+++ b/custom_components/oura/sensor.py
@@ -102,6 +102,9 @@ class OuraSensor(CoordinatorEntity[OuraDataUpdateCoordinator], SensorEntity):
         if self._sensor_type.startswith("last_workout_") and "_last_workout_raw" in self.coordinator.data:
             attrs["workout"] = self.coordinator.data["_last_workout_raw"]
 
+        if self._sensor_type == "workouts_today" and "_workouts_today_list" in self.coordinator.data:
+            attrs["workouts"] = self.coordinator.data["_workouts_today_list"]
+
         return attrs or None
 
     @property

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -416,7 +416,11 @@ def test_empty_data_handling():
 
     # Should return dict with default values without errors
     assert isinstance(processed, dict)
-    assert processed == {"rest_mode_active": False, "workouts_today": 0}
+    assert processed == {
+        "rest_mode_active": False,
+        "workouts_today": 0,
+        "_workouts_today_list": [],
+    }
 
 
 def test_process_workout_data():
@@ -445,11 +449,87 @@ def test_process_workout_data():
     coordinator._process_workout(data, processed)
 
     assert processed["workouts_today"] == 1
+    assert processed["_workouts_today_list"] == data["workout"]["data"]
     assert processed["last_workout_type"] == "running"
     assert processed["last_workout_distance"] == 5000
     assert processed["last_workout_calories"] == 320
     assert processed["last_workout_intensity"] == "moderate"
     assert processed["last_workout_duration"] == 30
+
+
+def test_process_workout_multiple_today():
+    """Test that all of today's workouts are exposed, not just the latest."""
+    from datetime import datetime, timedelta, timezone
+
+    coordinator = MockCoordinator()
+    today = datetime.now(timezone.utc).date().isoformat()
+    yesterday = (datetime.now(timezone.utc).date() - timedelta(days=1)).isoformat()
+    strength = {
+        "day": today,
+        "activity": "strength_training",
+        "calories": 250,
+        "intensity": "hard",
+        "start_datetime": f"{today}T06:00:00+00:00",
+        "end_datetime": f"{today}T06:45:00+00:00",
+    }
+    cycling = {
+        "day": today,
+        "activity": "cycling",
+        "distance": 15000,
+        "calories": 400,
+        "intensity": "moderate",
+        "start_datetime": f"{today}T07:00:00+00:00",
+        "end_datetime": f"{today}T08:00:00+00:00",
+    }
+    data = {
+        "workout": {
+            "data": [
+                {
+                    "day": yesterday,
+                    "activity": "walking",
+                    "start_datetime": f"{yesterday}T18:00:00+00:00",
+                    "end_datetime": f"{yesterday}T18:30:00+00:00",
+                },
+                strength,
+                cycling,
+            ]
+        }
+    }
+
+    processed = {}
+    coordinator._process_workout(data, processed)
+
+    assert processed["workouts_today"] == 2
+    assert processed["_workouts_today_list"] == [strength, cycling]
+    assert processed["last_workout_type"] == "cycling"
+
+
+def test_process_workout_none_today():
+    """Test that the count and list are empty when all workouts are from earlier days."""
+    from datetime import datetime, timedelta, timezone
+
+    coordinator = MockCoordinator()
+    yesterday = (datetime.now(timezone.utc).date() - timedelta(days=1)).isoformat()
+    # The API window still contains yesterday's workout just after midnight
+    data = {
+        "workout": {
+            "data": [
+                {
+                    "day": yesterday,
+                    "activity": "walking",
+                    "start_datetime": f"{yesterday}T18:00:00+00:00",
+                    "end_datetime": f"{yesterday}T18:30:00+00:00",
+                }
+            ]
+        }
+    }
+
+    processed = {}
+    coordinator._process_workout(data, processed)
+
+    assert processed["workouts_today"] == 0
+    assert processed["_workouts_today_list"] == []
+    assert processed["last_workout_type"] == "walking"
 
 
 def test_process_workout_preserves_last_values():
@@ -471,6 +551,7 @@ def test_process_workout_preserves_last_values():
     coordinator._process_workout(data, processed)
 
     assert processed["workouts_today"] == 0
+    assert processed["_workouts_today_list"] == []
     assert processed["last_workout_type"] == "cycling"
     assert processed["last_workout_distance"] == 10000
     assert processed["last_workout_calories"] == 500
@@ -489,6 +570,7 @@ def test_process_workout_no_previous_data():
     coordinator._process_workout(data, processed)
 
     assert processed["workouts_today"] == 0
+    assert processed["_workouts_today_list"] == []
     assert "last_workout_type" not in processed
     assert "last_workout_distance" not in processed
     assert "last_workout_calories" not in processed

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -178,6 +178,59 @@ def test_workout_sensor_exposes_raw_workout_attribute(mock_coordinator):
     assert sensor.extra_state_attributes == {"workout": {"activity": "running", "distance": 5000}}
 
 
+def test_workouts_today_sensor_exposes_workout_list(mock_coordinator):
+    """Test workouts_today sensor exposes the full list of today's workouts."""
+    workouts = [
+        {"activity": "strength_training", "start_datetime": "2026-03-24T06:00:00+00:00"},
+        {"activity": "cycling", "start_datetime": "2026-03-24T07:00:00+00:00"},
+    ]
+    mock_coordinator.data = {
+        "workouts_today": 2,
+        "_workouts_today_list": workouts,
+    }
+
+    sensor = OuraSensor(
+        coordinator=mock_coordinator,
+        sensor_type="workouts_today",
+        sensor_info=SENSOR_TYPES["workouts_today"],
+    )
+
+    assert sensor.native_value == 2
+    assert sensor.extra_state_attributes == {"workouts": workouts}
+
+
+def test_workouts_attribute_not_on_other_sensors(mock_coordinator):
+    """Test that other sensors don't pick up the workouts attribute."""
+    mock_coordinator.data = {
+        "sleep_score": 82,
+        "workouts_today": 1,
+        "_workouts_today_list": [{"activity": "running"}],
+    }
+
+    sensor = OuraSensor(
+        coordinator=mock_coordinator,
+        sensor_type="sleep_score",
+        sensor_info=SENSOR_TYPES["sleep_score"],
+    )
+
+    assert sensor.native_value == 82
+    assert sensor.extra_state_attributes is None
+
+
+def test_workouts_today_sensor_without_list(mock_coordinator):
+    """Test workouts_today attributes when no list has been published."""
+    mock_coordinator.data = {"workouts_today": 0}
+
+    sensor = OuraSensor(
+        coordinator=mock_coordinator,
+        sensor_type="workouts_today",
+        sensor_info=SENSOR_TYPES["workouts_today"],
+    )
+
+    assert sensor.native_value == 0
+    assert sensor.extra_state_attributes is None
+
+
 def test_rest_mode_binary_sensor(mock_coordinator):
     """Test rest mode binary sensor state and attributes."""
     mock_coordinator.data = {


### PR DESCRIPTION
workouts_today only reports a count, and the last_workout_* sensors only carry the most recent workout. On days with more than one workout (a strength session followed by a ride, for example) anything reading HA state can only see the latest one.

The coordinator already builds a today_workouts list to compute the count, then discards it. This PR publishes that list as _workouts_today_list and exposes it as a workouts attribute on the workouts_today sensor, following the existing tags_today / _tags_today_list and last_workout_* / _last_workout_raw patterns in extra_state_attributes.

Behavior:
- State is unchanged (still the count).
- New workouts attribute: the day's workouts as returned by /v2/usercollection/workout (the raw API fields: id, activity, day, start/end datetimes, intensity, source, plus label, calories and distance when present).
- Resets to an empty list when the API window has no workout data or only contains previous days' workouts, matching the count resetting to 0.
- last_workout_* sensors are untouched.

Testing: full pytest suite passes (113 tests). New coverage: a multi-workout day, a window containing only a previous day's workouts, the sensor attribute and its guards, and the empty-window reset; one pre-existing exact-equality test (test_empty_data_handling) updated for the new key. Also running this change live on my own Home Assistant instance.
