### PR TITLE
fix: raise ConfigEntryAuthFailed on OAuth refresh rejection

### DIFF
--- a/custom_components/oura/api.py
+++ b/custom_components/oura/api.py
@@ -9,7 +9,10 @@ from zoneinfo import ZoneInfo
 
 from aiohttp import ClientSession, ClientResponseError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    OAuth2Session,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 
@@ -71,6 +74,14 @@ class OuraApiClient:
             *(getattr(self, method_name)(start_date, end_date) for method_name in API_ENDPOINTS.values()),
             return_exceptions=True,
         )
+
+        # A rejected refresh_token fails every endpoint identically, and each one
+        # would otherwise be swallowed below as an ordinary per-endpoint outage
+        # (data[key] = {}), which hides the fact that reauthentication is needed.
+        # Propagate it so the coordinator can convert it into ConfigEntryAuthFailed.
+        for result in results:
+            if isinstance(result, OAuth2TokenRequestReauthError):
+                raise result
 
         data: dict[str, Any] = {}
         failed_endpoints = 0

--- a/custom_components/oura/coordinator.py
+++ b/custom_components/oura/coordinator.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.config_entry_oauth2_flow import OAuth2TokenRequestReauthError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -61,11 +63,25 @@ class OuraDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             return processed_data
 
+        except OAuth2TokenRequestReauthError as err:
+            # Oura's token endpoint rejected our refresh_token (HTTP 4xx from
+            # /oauth/token). The credentials are no longer valid — falling through to
+            # the generic handler below would silently keep serving stale data forever,
+            # since HA never gets the chance to raise the "Reauthenticate" UI prompt.
+            _LOGGER.warning(
+                "Oura token refresh rejected by the API (reauthentication required): %s",
+                err,
+            )
+            raise ConfigEntryAuthFailed(
+                f"Oura token refresh was rejected, reauthentication required: {err}"
+            ) from err
+
         except Exception as err:
             # Log the error but keep existing data to maintain sensor states
             # This handles transient network issues gracefully
             _LOGGER.warning(
-                "Error communicating with API (will retry in %s minutes): %s",
+                "Error communicating with API (%s) (will retry in %s minutes): %s",
+                type(err).__name__,
                 self.update_interval.total_seconds() / 60,
                 err
             )


### PR DESCRIPTION
The coordinator's blanket `except Exception` treated a rejected token refresh (HTTP 4xx from /oauth/token) the same as a transient network error, silently re-serving stale data forever once self.data was populated. This meant HA's "Reauthenticate" prompt could never appear, since nothing ever raised ConfigEntryAuthFailed.

Add a dedicated except clause for OAuth2TokenRequestReauthError, raised before the generic handler, so a genuine auth failure now surfaces HA's reauth flow (already implemented in config_flow.py via async_step_reauth/async_step_reauth_confirm, but previously unreachable).

Related: #61