### PR TITLE
fix: let a rejected refresh token escape the heart rate endpoint

### DIFF
--- a/custom_components/oura/api.py
+++ b/custom_components/oura/api.py
@@ -148,6 +148,11 @@ class OuraApiClient:
                 try:
                     batch = await self._async_get_all_pages(url, params)
                     all_data.extend(batch)
+                except OAuth2TokenRequestReauthError:
+                    # A rejected refresh token is not a per-batch outage: it
+                    # must reach async_get_data so the coordinator can raise
+                    # ConfigEntryAuthFailed, as the comment there states.
+                    raise
                 except Exception as err:
                     _LOGGER.warning(
                         "Failed to fetch heart rate data for %s to %s: %s",
@@ -162,6 +167,8 @@ class OuraApiClient:
         }
         try:
             return {"data": await self._async_get_all_pages(url, params)}
+        except OAuth2TokenRequestReauthError:
+            raise
         except Exception as err:
             _LOGGER.debug("Heart rate endpoint failed: %s", err)
             return {"data": []}

--- a/tests/test_api_reauth_propagation.py
+++ b/tests/test_api_reauth_propagation.py
@@ -1,0 +1,87 @@
+"""A rejected refresh token must escape the heart rate endpoint.
+
+`async_get_data` already re-raises OAuth2TokenRequestReauthError out of the
+gather, so the coordinator can turn it into ConfigEntryAuthFailed. But that
+guard only sees exceptions the endpoint methods let out, and
+`_async_get_heartrate` catches broadly inside its own paging loop -- so a
+rejected token there was absorbed as an ordinary per-batch outage and the
+integration went on serving stale data instead of asking for reauth.
+"""
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    OAuth2TokenRequestReauthError,
+)
+
+from custom_components.oura.api import OuraApiClient
+
+
+def _client() -> OuraApiClient:
+    hass = MagicMock()
+    hass.config.time_zone = "UTC"
+    return OuraApiClient(hass, MagicMock(), MagicMock())
+
+
+@pytest.mark.anyio
+async def test_reauth_escapes_the_batched_path():
+    """Ranges over 30 days go through the batching loop."""
+    client = _client()
+    client._async_get_all_pages = AsyncMock(side_effect=OAuth2TokenRequestReauthError)
+
+    with pytest.raises(OAuth2TokenRequestReauthError):
+        await client._async_get_heartrate(date(2026, 1, 1), date(2026, 3, 31))
+
+
+@pytest.mark.anyio
+async def test_reauth_escapes_the_short_path():
+    """Ranges of 30 days or less skip the loop entirely."""
+    client = _client()
+    client._async_get_all_pages = AsyncMock(side_effect=OAuth2TokenRequestReauthError)
+
+    with pytest.raises(OAuth2TokenRequestReauthError):
+        await client._async_get_heartrate(date(2026, 3, 1), date(2026, 3, 15))
+
+
+@pytest.mark.anyio
+async def test_an_ordinary_failure_is_still_absorbed():
+    """The point is to single out reauth, not to stop tolerating outages."""
+    client = _client()
+    client._async_get_all_pages = AsyncMock(side_effect=TimeoutError("upstream down"))
+
+    assert await client._async_get_heartrate(date(2026, 3, 1), date(2026, 3, 15)) == {
+        "data": []
+    }
+
+
+@pytest.mark.anyio
+async def test_an_ordinary_failure_is_still_absorbed_when_batching():
+    """A dead batch must not abort the batches that follow it."""
+    client = _client()
+    client._async_get_all_pages = AsyncMock(
+        side_effect=[TimeoutError("upstream down"), [{"bpm": 60}], [{"bpm": 61}]]
+    )
+
+    result = await client._async_get_heartrate(date(2026, 1, 1), date(2026, 3, 31))
+
+    assert result == {"data": [{"bpm": 60}, {"bpm": 61}]}
+
+
+@pytest.mark.anyio
+async def test_reauth_reaches_async_get_data_through_the_gather():
+    """End to end: the outer guard can only fire if the inner one lets go."""
+    client = _client()
+    for name in (
+        "_async_get_sleep", "_async_get_readiness", "_async_get_activity",
+        "_async_get_sleep_detail", "_async_get_stress", "_async_get_resilience",
+        "_async_get_spo2", "_async_get_vo2_max", "_async_get_cardiovascular_age",
+        "_async_get_sleep_time", "_async_get_workout", "_async_get_session",
+        "_async_get_tag", "_async_get_enhanced_tag", "_async_get_rest_mode",
+        "_async_get_ring_battery_level", "_async_get_ring_configuration",
+    ):
+        setattr(client, name, AsyncMock(return_value={"data": []}))
+    client._async_get_all_pages = AsyncMock(side_effect=OAuth2TokenRequestReauthError)
+
+    with pytest.raises(OAuth2TokenRequestReauthError):
+        await client.async_get_data(days_back=90)

--- a/tests/test_api_reauth_propagation.py
+++ b/tests/test_api_reauth_propagation.py
@@ -11,11 +11,30 @@ from datetime import date
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiohttp import RequestInfo
 from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2TokenRequestReauthError,
 )
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
 
 from custom_components.oura.api import OuraApiClient
+
+_TOKEN_URL = URL("https://api.ouraring.com/oauth/token")
+
+
+def _reauth_error() -> OAuth2TokenRequestReauthError:
+    """Build a real one -- it subclasses ClientResponseError and needs the lot.
+
+    Raising the bare class instead would blow up as a TypeError, which the
+    broad `except` absorbs, and the test would pass for the wrong reason.
+    """
+    request_info = RequestInfo(
+        _TOKEN_URL, "POST", CIMultiDictProxy(CIMultiDict()), _TOKEN_URL
+    )
+    return OAuth2TokenRequestReauthError(
+        domain="oura", request_info=request_info, history=(), status=400
+    )
 
 
 def _client() -> OuraApiClient:
@@ -28,7 +47,7 @@ def _client() -> OuraApiClient:
 async def test_reauth_escapes_the_batched_path():
     """Ranges over 30 days go through the batching loop."""
     client = _client()
-    client._async_get_all_pages = AsyncMock(side_effect=OAuth2TokenRequestReauthError)
+    client._async_get_all_pages = AsyncMock(side_effect=_reauth_error())
 
     with pytest.raises(OAuth2TokenRequestReauthError):
         await client._async_get_heartrate(date(2026, 1, 1), date(2026, 3, 31))
@@ -38,7 +57,7 @@ async def test_reauth_escapes_the_batched_path():
 async def test_reauth_escapes_the_short_path():
     """Ranges of 30 days or less skip the loop entirely."""
     client = _client()
-    client._async_get_all_pages = AsyncMock(side_effect=OAuth2TokenRequestReauthError)
+    client._async_get_all_pages = AsyncMock(side_effect=_reauth_error())
 
     with pytest.raises(OAuth2TokenRequestReauthError):
         await client._async_get_heartrate(date(2026, 3, 1), date(2026, 3, 15))
@@ -81,7 +100,7 @@ async def test_reauth_reaches_async_get_data_through_the_gather():
         "_async_get_ring_battery_level", "_async_get_ring_configuration",
     ):
         setattr(client, name, AsyncMock(return_value={"data": []}))
-    client._async_get_all_pages = AsyncMock(side_effect=OAuth2TokenRequestReauthError)
+    client._async_get_all_pages = AsyncMock(side_effect=_reauth_error())
 
     with pytest.raises(OAuth2TokenRequestReauthError):
         await client.async_get_data(days_back=90)


### PR DESCRIPTION
## The gap

`async_get_data` already re-raises `OAuth2TokenRequestReauthError` out of the `asyncio.gather`, so the coordinator can turn it into `ConfigEntryAuthFailed` (added in 0341140). That guard is correct, but it can only see exceptions the endpoint methods let out.

`_async_get_heartrate` doesn't let this one out. It catches broadly inside its own paging loop:

```python
try:
    batch = await self._async_get_all_pages(url, params)
    all_data.extend(batch)
except Exception as err:
    _LOGGER.warning("Failed to fetch heart rate data for %s to %s: %s", ...)
```

So when the refresh token is rejected, every batch is absorbed as an ordinary per-endpoint outage, `_async_get_heartrate` returns normally, and the gather never sees the error. The integration keeps serving stale data instead of asking the user to reauthenticate — which is exactly what the existing guard was written to prevent.

Same shape in the short (≤30 day) path a few lines below.

## The change

Re-raise `OAuth2TokenRequestReauthError` in both paths, ahead of the broad `except`. Every other failure stays absorbed exactly as before — a dead batch still logs and lets the following batches through, and a failed short-path request still returns `{"data": []}`.

## Tests

Five new tests in `tests/test_api_reauth_propagation.py`:

- reauth escapes the batched path
- reauth escapes the short path
- an ordinary failure is still absorbed
- an ordinary failure while batching doesn't abort the batches after it
- end to end: it reaches `async_get_data` through the gather

**With the two `raise` clauses removed and everything else left in place, three of the five fail.** The two "still absorbed" tests pass either way, which is what they are for.

Full suite: **118 passed** on `homeassistant==2026.6.0` / Python 3.14, matching the pinned test image.

One note on the tests, since it bit me: raising the bare `OAuth2TokenRequestReauthError` class does not work here. It subclasses `ClientResponseError` and requires `domain`, `request_info`, `history` and `status`, so an argument-less construction fails as a `TypeError` — which the very `except Exception` under test then absorbs. Three tests passed for the wrong reason until I built a real instance.

## Not verified against a live account

I could not force a genuinely rejected refresh token, so this is verified by test, not against the Oura API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
