### PR TITLE
fix: fallback to new-portal token endpoint on 400 (v2.8.6)

### DIFF
--- a/custom_components/oura/application_credentials.py
+++ b/custom_components/oura/application_credentials.py
@@ -1,13 +1,63 @@
 """Application credentials platform for Oura Ring."""
-from homeassistant.components.application_credentials import AuthorizationServer
-from homeassistant.core import HomeAssistant
+import logging
 
-from .const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from homeassistant.components.application_credentials import (
+    AuthImplementation,
+    AuthorizationServer,
+    ClientCredential,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.config_entry_oauth2_flow import OAuth2TokenRequestReauthError
+
+from .const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN, OAUTH2_TOKEN_FALLBACK
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OuraOAuth2Implementation(AuthImplementation):
+    """OAuth2 impl with automatic fallback to the new-portal token endpoint.
+
+    Apps registered on developer.ouraring.com return 400 invalid_request when
+    refreshing against the legacy api.ouraring.com/oauth/token endpoint. On the
+    first such rejection we transparently retry against the new endpoint and
+    update self.token_url so all subsequent requests go there directly.
+    """
+
+    async def _token_request(self, data: dict) -> dict:
+        """Make a token request, falling back to the new endpoint on 400."""
+        try:
+            return await super()._token_request(data)
+        except OAuth2TokenRequestReauthError:
+            if self.token_url == OAUTH2_TOKEN_FALLBACK:
+                raise
+            _LOGGER.debug(
+                "Legacy token endpoint rejected the request; retrying against %s",
+                OAUTH2_TOKEN_FALLBACK,
+            )
+            self.token_url = OAUTH2_TOKEN_FALLBACK
+            return await super()._token_request(data)
 
 
 async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationServer:
-    """Return authorization server."""
+    """Return authorization server (used by the default impl path)."""
     return AuthorizationServer(
         authorize_url=OAUTH2_AUTHORIZE,
         token_url=OAUTH2_TOKEN,
+    )
+
+
+async def async_get_auth_implementation(
+    hass: HomeAssistant,
+    auth_domain: str,
+    credential: ClientCredential,
+) -> OuraOAuth2Implementation:
+    """Return the custom impl that handles the new-portal token endpoint."""
+    return OuraOAuth2Implementation(
+        hass,
+        auth_domain,
+        credential,
+        AuthorizationServer(
+            authorize_url=OAUTH2_AUTHORIZE,
+            token_url=OAUTH2_TOKEN,
+        ),
     )

--- a/custom_components/oura/const.py
+++ b/custom_components/oura/const.py
@@ -25,7 +25,9 @@ CONF_HISTORICAL_DATA_IMPORTED: Final = "historical_data_imported"
 
 # OAuth2 Constants
 OAUTH2_AUTHORIZE: Final = "https://cloud.ouraring.com/oauth/authorize"
+# Legacy endpoint (cloud.ouraring.com apps); new-portal apps use the fallback below.
 OAUTH2_TOKEN: Final = "https://api.ouraring.com/oauth/token"
+OAUTH2_TOKEN_FALLBACK: Final = "https://moi.ouraring.com/oauth/v2/ext/oauth-token"
 OAUTH2_SCOPES: Final = [
     "email",
     "personal",

--- a/custom_components/oura/manifest.json
+++ b/custom_components/oura/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/louispires/oura-v2-custom-component/issues",
   "requirements": [],
-  "version": "2.8.5"
+  "version": "2.8.6"
 }

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,4 +1,26 @@
-﻿# Oura Ring v2 Integration v2.8.5
+﻿# Oura Ring v2 Integration v2.8.6
+
+## 🐛 BUG FIX IN v2.8.6
+
+### Token refresh now works for apps registered on the new Oura developer portal
+
+- **Fixed**: Apps registered on the new [developer.ouraring.com](https://developer.ouraring.com) portal fail every token refresh against the legacy `https://api.ouraring.com/oauth/token` endpoint with `400 invalid_request`, causing all 18 endpoints to fail simultaneously on every update cycle ([#68](https://github.com/louispires/Oura-Home-Assistant-Integration/issues/68), root cause of [#61](https://github.com/louispires/Oura-Home-Assistant-Integration/issues/61) / [#54](https://github.com/louispires/Oura-Home-Assistant-Integration/issues/54)).
+- **Fix**: A custom `OuraOAuth2Implementation` now tries the legacy endpoint first; on a `400` rejection it transparently retries against `https://moi.ouraring.com/oauth/v2/ext/oauth-token` (the new-portal endpoint) and updates `token_url` permanently for that session so all subsequent refreshes go directly there. Apps registered on the legacy portal are unaffected — they succeed on the first attempt and the fallback never fires.
+
+**Why a fallback rather than a hard switch**: the new endpoint is undocumented and has not been confirmed to accept legacy-portal credentials. The fallback strategy keeps both old and new portal users working without requiring a re-registration or any user action.
+
+## 🧪 TESTING & VALIDATION
+
+- ✅ Full Docker suite passing: **123 tests passed**
+- ✅ New tests added for all fallback paths:
+  - `test_legacy_success_no_fallback` — legacy endpoint succeeds, `token_url` unchanged.
+  - `test_legacy_400_retries_fallback_and_succeeds` — legacy 400 → retry against new endpoint → success, `token_url` updated.
+  - `test_fallback_400_propagates_reauth_error` — both endpoints 400 → `OAuth2TokenRequestReauthError` propagates to coordinator → reauthentication prompt appears in HA UI.
+  - `test_second_call_goes_directly_to_fallback` — after the switch, subsequent calls use the fallback directly with no extra retry.
+
+---
+
+# Oura Ring v2 Integration v2.8.5
 
 ## 🐛 BUG FIXES IN v2.8.5
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,2 @@
 anyio[trio]
+aiohttp

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,147 +1,136 @@
 # Test Suite Documentation
 
-This directory contains the comprehensive test suite for the Oura Ring Home Assistant integration.
+This directory contains the automated test suite and live diagnostic scripts for the Oura Ring Home Assistant integration.
 
 ## Test Structure
 
-The test suite is organized into focused test modules:
+### Automated Tests (123 tests)
 
-### Unit Tests
+- **`test_api.py`** (2 tests)
+  - Timezone-aware date window and exclusive end-date construction
+  - Absorbed heart rate outage counted in aggregate failure totals
 
-- **`test_sensor.py`** (7 tests)
-  - Device info configuration
-  - Modern entity naming with `has_entity_name=True`
-  - Translation keys
-  - Entity availability logic
-  - Unique ID generation
+- **`test_api_reauth_propagation.py`** (5 tests)
+  - `OAuth2TokenRequestReauthError` escapes the batched heart rate fetch path
+  - `OAuth2TokenRequestReauthError` escapes the short-range heart rate fetch path
+  - Ordinary non-auth failures are still absorbed (graceful degradation preserved)
+  - Ordinary failures absorbed in the batched path too
+  - Reauth error propagates through `asyncio.gather` to the coordinator
 
-- **`test_statistics.py`** (6 tests)
-  - Statistics metadata completeness
-  - Data source configuration structure
-  - Timestamp parsing functions
-  - Value transformation helpers
-  - Nested value extraction
+- **`test_application_credentials.py`** (4 tests)
+  - Legacy endpoint succeeds → fallback never fires, `token_url` unchanged
+  - Legacy 400 → retry against new-portal endpoint → success, `token_url` updated
+  - Both endpoints 400 → `OAuth2TokenRequestReauthError` propagates to coordinator
+  - Already on fallback endpoint → succeeds in one call, no extra retry
 
-- **`test_coordinator.py`** (13 tests)
-  - Individual processing methods for each data type
-  - Sleep score and detail processing
-  - Readiness, activity, and heart rate handling
-  - Stress, resilience, SpO2, VO2 Max processing
-  - Overall data orchestration
-  - Empty data handling
+- **`test_config_flow.py`** (5 tests)
+  - Personal info fetch success and token plumbing
+  - Unique ID derived from Oura user ID
+  - Config entry title from email address
+  - Title fallback when email is absent
+  - Multiple accounts with different IDs accepted
 
-- **`test_entity_categories.py`** (6 tests)
-  - Entity category assignments
-  - State class improvements (`total`, `total_increasing`)
-  - Measurement vs diagnostic categories
-  - Text sensor handling
-  - Primary sensors not marked as diagnostic
+- **`test_coordinator.py`** (38 tests)
+  - Processing methods for every data category: sleep scores, sleep details, readiness, activity, heart rate, stress, resilience, SpO2, VO2 Max, cardiovascular age, sleep time, workout, session, tags, rest mode
+  - Bedtime selection: in-progress records filtered, longest sleep preferred, fallback to existing when no completed record
+  - Activity time field presence and absence
+  - Heart rate sorting, 24-hour aggregation, and 10-reading fallback
+  - Sleep detail date sorting and age filtering
+  - Cardiovascular age with and without pulse wave velocity
+  - Bedtime tie-breaking by total sleep duration (same day)
 
-### Integration Tests
+- **`test_entity_categories.py`** (7 tests)
+  - Entity category assignments (primary vs diagnostic)
+  - `low_battery_alert` metadata
+  - `total` / `total_increasing` state class assignments
+  - Measurement state classes
+  - Text sensors have no state class
+  - All sensors have an entity category key
+  - Primary sensors not marked diagnostic
 
 - **`test_integration_setup.py`** (7 tests)
-  - Fixture validation tests
-  - Config entry setup
-  - OAuth2 session mocking
-  - API client mocking
-  - Coordinator mocking
+  - Fixture validation: config entry, hass, API data, API client, OAuth2 session, coordinator, empty response
+
+- **`test_ring_battery.py`** (30 tests)
+  - Battery level and charging state processing
+  - Edge cases: missing fields, empty data
+  - Most-recent ring configuration selection (order-independent, parametrized)
+  - Timestamp edge cases: missing, naive, invalid
+  - API method: `latest=true` param, 401/404 graceful handling
+  - Ring charging binary sensor: `is_on` and availability logic
+  - Device info enrichment: hardware type display names, firmware version, fallback
+
+- **`test_sensor.py`** (15 tests)
+  - Device info, unique IDs, `has_entity_name`, translation keys
+  - `native_value` and availability gating
+  - Boolean sensors, tags attributes, workout attributes, `workouts_today` list
+  - Rest mode binary sensor
+
+- **`test_statistics.py`** (9 tests)
+  - Metadata completeness and state class alignment
+  - Sleep efficiency field mapping
+  - Timestamp parsing, value transforms, percentage computation, nested value extraction
+  - Cumulative sum accumulation
+
+- **`test_statistics_import.py`** (2 tests)
+  - Statistics import when entity exists
+  - Statistics import when entity is missing
+
+## Live / Diagnostic Scripts
+
+These scripts run against real Oura credentials and are not part of the automated suite. They are not collected by pytest.
+
+- **`live_heartrate_test.py`** — fetches live heart rate data and reports freshness and pagination. Requires `OURA_TOKEN` (Personal Access Token).
+- **`live_token_endpoint_test.py`** — probes both OAuth token endpoints to determine which one accepts your app's refresh token (useful for diagnosing new-portal vs legacy-portal apps). Requires `OURA_CLIENT_ID`, `OURA_CLIENT_SECRET`, `OURA_REFRESH_TOKEN`.
+- **`get_refresh_token.py`** — runs a local OAuth2 authorization code flow to obtain a refresh token from scratch. Requires `OURA_CLIENT_ID`, `OURA_CLIENT_SECRET`, and `http://localhost:8765/callback` registered as a redirect URI in your Oura app.
 
 ## Test Fixtures (`conftest.py`)
 
-The `conftest.py` file provides reusable pytest fixtures for all tests:
-
-### Core Fixtures
-
-- **`mock_config_entry`**: Fully configured ConfigEntry with OAuth2 token data
-- **`mock_hass`**: Mocked HomeAssistant instance with proper spec
-- **`mock_oura_api_client`**: AsyncMock API client with sample response data
-- **`mock_oauth2_session`**: Mocked OAuth2 session with token refresh
-- **`mock_coordinator_with_data`**: Coordinator with pre-populated data
-
-### Data Fixtures
-
-- **`mock_oura_api_data`**: Complete sample API response with all data types
-- **`mock_empty_api_response`**: Empty API response for unavailable sensor testing
+- **`mock_config_entry`** — ConfigEntry with OAuth2 token data
+- **`mock_hass`** — mocked `HomeAssistant` instance
+- **`mock_oura_api_client`** — `AsyncMock` API client with sample responses
+- **`mock_oauth2_session`** — mocked OAuth2 session with token refresh
+- **`mock_coordinator_with_data`** — coordinator with pre-populated data
+- **`mock_oura_api_data`** — complete sample API response covering all data types
+- **`mock_empty_api_response`** — empty response for unavailable-sensor testing
 
 ## Running Tests
 
-### Using Docker (Recommended)
+### Using Docker (required — local venv lacks HA test deps)
 
-Run all tests:
 ```bash
-docker-compose -f docker-compose.test.yml run --rm test pytest tests/ -v
+# Full suite
+docker compose -f docker-compose.test.yml run --rm test
+
+# Single file
+docker compose -f docker-compose.test.yml run --rm test pytest tests/test_sensor.py -v
+
+# Single test
+docker compose -f docker-compose.test.yml run --rm test pytest tests/test_coordinator.py::test_process_sleep_scores -v
 ```
 
-Run a specific test file:
+### Running Live Scripts
+
 ```bash
-docker-compose -f docker-compose.test.yml run --rm test pytest tests/test_sensor.py -v
+# Heart rate freshness probe
+$env:OURA_TOKEN = "your-personal-access-token"
+python tests/live_heartrate_test.py
+
+# Token endpoint probe (which OAuth endpoint accepts your app)
+$env:OURA_CLIENT_ID     = "your-client-id"
+$env:OURA_CLIENT_SECRET = "your-client-secret"
+$env:OURA_REFRESH_TOKEN = "your-refresh-token"
+python tests/live_token_endpoint_test.py
+
+# Obtain a refresh token via browser OAuth flow (run once)
+$env:OURA_CLIENT_ID     = "your-client-id"
+$env:OURA_CLIENT_SECRET = "your-client-secret"
+python tests/get_refresh_token.py
 ```
-
-Run a specific test:
-```bash
-docker-compose -f docker-compose.test.yml run --rm test pytest tests/test_sensor.py::test_sensor_device_info -v
-```
-
-### Using Local Python Environment
-
-If you have the Home Assistant dependencies installed locally:
-```bash
-pytest tests/ -v
-```
-
-## Test Coverage
-
-Current test coverage:
-
-- **Total Tests**: 39
-- **Passing**: 39 (100%)
-- **Coverage Areas**:
-  - ✅ Sensor entity configuration
-  - ✅ Statistics module helpers
-  - ✅ Coordinator data processing
-  - ✅ Entity categories and state classes
-  - ✅ Test fixtures and infrastructure
 
 ## Adding New Tests
 
-When adding new tests:
-
-1. **Use Existing Fixtures**: Leverage fixtures from `conftest.py` to reduce boilerplate
-2. **Follow Naming Conventions**: Test files should start with `test_`, test functions should start with `test_`
-3. **Keep Tests Focused**: Each test should verify a single behavior
-4. **Use Descriptive Names**: Test names should clearly describe what they're testing
-5. **Add Docstrings**: Brief description of what the test validates
-
-### Example Test Structure
-
-```python
-def test_sensor_behavior(mock_coordinator_with_data, mock_config_entry):
-    """Test that sensor behaves correctly with valid data."""
-    # Arrange
-    sensor = OuraSensor(mock_coordinator_with_data, "sleep_score")
-    
-    # Act
-    result = sensor.native_value
-    
-    # Assert
-    assert result == 85
-```
-
-## Continuous Integration
-
-Tests are designed to run in CI environments:
-
-- Uses Docker for consistent test environment
-- Home Assistant 2025.11 base image
-- No native dependencies required
-- Fast execution (~0.15s for all tests)
-
-## Future Enhancements
-
-Potential test improvements:
-
-- Add async integration tests for full setup/teardown flow
-- Add config flow tests for OAuth2 authentication
-- Add API client tests with real request/response mocking
-- Increase test coverage for error handling paths
-- Add performance benchmarking tests
+1. Match the existing async pattern: `@pytest.mark.anyio` with `asyncio_mode = "auto"` (set in `pytest.ini`)
+2. Use fixtures from `conftest.py` to reduce boilerplate
+3. Test files must start with `test_`; live/diagnostic scripts must not (to avoid pytest collection)
+4. Run via Docker to verify — the local venv does not have HA test dependencies

--- a/tests/get_refresh_token.py
+++ b/tests/get_refresh_token.py
@@ -1,0 +1,139 @@
+"""One-shot OAuth2 flow to obtain a refresh_token from Oura.
+
+Run this once to get your refresh_token, then use it with live_token_endpoint_test.py.
+
+Prerequisites:
+    1. In your Oura app at developer.ouraring.com → Edit → Redirect URIs,
+       add:  http://localhost:8765/callback
+    2. Set environment variables:
+           OURA_CLIENT_ID      your client ID
+           OURA_CLIENT_SECRET  your client secret
+    3. Run:
+           python tests/get_refresh_token.py
+
+The script opens your browser, waits for you to authorise, then prints
+the access_token and refresh_token. It does not store them anywhere.
+"""
+import asyncio
+import json
+import os
+import sys
+import urllib.parse
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+
+try:
+    import aiohttp
+except ImportError:
+    print("ERROR: aiohttp not installed. Run: pip install aiohttp")
+    sys.exit(1)
+
+AUTHORIZE_URL = "https://cloud.ouraring.com/oauth/authorize"
+TOKEN_URL = "https://api.ouraring.com/oauth/token"
+REDIRECT_URI = "http://localhost:8765/callback"
+SCOPES = "email personal daily heartrate workout session tag spo2 ring_configuration stress heart_health"
+
+_auth_code: str | None = None
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):  # silence access logs
+        pass
+
+    def do_GET(self):
+        global _auth_code
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+
+        if "error" in params:
+            error = params["error"][0]
+            desc = params.get("error_description", [""])[0]
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(f"Authorization failed: {error} — {desc}".encode())
+            print(f"\nERROR: Oura returned: {error}: {desc}")
+        elif "code" in params:
+            _auth_code = params["code"][0]
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"<h2>Authorised. You can close this tab.</h2>")
+        else:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b"Missing code parameter.")
+
+
+def _run_server(server: HTTPServer) -> None:
+    server.handle_request()  # serve exactly one request then exit
+
+
+async def exchange_code(client_id: str, client_secret: str, code: str) -> dict:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            TOKEN_URL,
+            data={
+                "grant_type": "authorization_code",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "code": code,
+                "redirect_uri": REDIRECT_URI,
+            },
+        ) as resp:
+            body = await resp.text()
+            if resp.status != 200:
+                print(f"Token exchange failed (HTTP {resp.status}): {body}")
+                sys.exit(1)
+            return json.loads(body)
+
+
+def main() -> None:
+    client_id = os.environ.get("OURA_CLIENT_ID", "").strip()
+    client_secret = os.environ.get("OURA_CLIENT_SECRET", "").strip()
+    if not client_id or not client_secret:
+        print("ERROR: set OURA_CLIENT_ID and OURA_CLIENT_SECRET environment variables.")
+        sys.exit(1)
+
+    params = urllib.parse.urlencode({
+        "client_id": client_id,
+        "redirect_uri": REDIRECT_URI,
+        "response_type": "code",
+        "scope": SCOPES,
+    })
+    auth_url = f"{AUTHORIZE_URL}?{params}"
+
+    server = HTTPServer(("localhost", 8765), _CallbackHandler)
+    thread = Thread(target=_run_server, args=(server,), daemon=True)
+    thread.start()
+
+    print(f"Opening browser for authorisation...")
+    print(f"(If the browser doesn't open, visit this URL manually:)\n{auth_url}\n")
+    webbrowser.open(auth_url)
+
+    print("Waiting for Oura to redirect back to localhost:8765 ...")
+    thread.join(timeout=120)
+
+    if not _auth_code:
+        print("ERROR: No authorisation code received within 2 minutes.")
+        sys.exit(1)
+
+    print("Exchanging code for tokens...")
+    tokens = asyncio.run(exchange_code(client_id, client_secret, _auth_code))
+
+    access = tokens.get("access_token", "")
+    refresh = tokens.get("refresh_token", "")
+    expires = tokens.get("expires_in", "?")
+
+    print("\n" + "─" * 60)
+    print(f"access_token  : {access[:16]}...  (expires in {expires}s)")
+    print(f"refresh_token : {refresh}")
+    print("─" * 60)
+    print("\nTo run the endpoint probe:")
+    print(f'  $env:OURA_CLIENT_ID="{client_id}"')
+    print(f'  $env:OURA_CLIENT_SECRET="<your-secret>"')
+    print(f'  $env:OURA_REFRESH_TOKEN="{refresh}"')
+    print("  python tests/live_token_endpoint_test.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/live_token_endpoint_test.py
+++ b/tests/live_token_endpoint_test.py
@@ -1,0 +1,117 @@
+"""Live test: probe which OAuth token endpoint accepts your app's refresh token.
+
+Useful for confirming whether your Oura app is a legacy-portal or new-portal
+app, and verifying that the fallback endpoint added in v2.8.6 works for your
+credentials before deploying the fix.
+
+Usage:
+    Set the three environment variables below, then run:
+
+        python tests/live_token_endpoint_test.py
+
+    OURA_CLIENT_ID      — OAuth client ID from your Oura developer app
+    OURA_CLIENT_SECRET  — OAuth client secret
+    OURA_REFRESH_TOKEN  — refresh_token from an existing OAuth session
+                          (copy from HA storage, or capture from a fresh auth flow)
+
+How to find your refresh_token in Home Assistant:
+    1. Open the HA file system (e.g. Studio Code Server, SSH, or Samba).
+    2. Look in .storage/core.config_entries — find the "oura" entry and copy the
+       token.refresh_token value.
+
+What this script does:
+    1. Tries the legacy endpoint (api.ouraring.com/oauth/token).
+    2. Tries the new-portal endpoint (moi.ouraring.com/oauth/v2/ext/oauth-token).
+    3. Reports which one(s) returned a new access token and which returned 400.
+
+Expected results:
+    Legacy-portal app: legacy ✅, new-portal probably ❌ (or also ✅)
+    New-portal app:    legacy ❌, new-portal ✅  (root cause of #68)
+"""
+import asyncio
+import json
+import os
+import sys
+
+try:
+    import aiohttp
+except ImportError:
+    print("ERROR: aiohttp not installed. Run: pip install aiohttp")
+    sys.exit(1)
+
+LEGACY_ENDPOINT = "https://api.ouraring.com/oauth/token"
+NEW_ENDPOINT = "https://moi.ouraring.com/oauth/v2/ext/oauth-token"
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        print(f"ERROR: environment variable {name} is not set.")
+        sys.exit(1)
+    return value
+
+
+async def try_refresh(
+    session: aiohttp.ClientSession,
+    endpoint: str,
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+) -> None:
+    label = endpoint.split("/")[2]  # hostname only, for readability
+    print(f"\n{'─' * 60}")
+    print(f"Endpoint : {endpoint}")
+    payload = {
+        "grant_type": "refresh_token",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "refresh_token": refresh_token,
+    }
+    try:
+        async with session.post(endpoint, data=payload) as resp:
+            body = await resp.text()
+            try:
+                data = json.loads(body)
+            except json.JSONDecodeError:
+                data = {}
+
+            if resp.status == 200 and "access_token" in data:
+                token_preview = data["access_token"][:12] + "..."
+                expires_in = data.get("expires_in", "?")
+                print(f"Result   : ✅ SUCCESS (HTTP 200)")
+                print(f"Token    : {token_preview}  expires_in={expires_in}s")
+                if "refresh_token" in data:
+                    print("Note     : A new refresh_token was also issued (rotate it).")
+            else:
+                error = data.get("error", "?")
+                description = data.get("error_description", body[:120])
+                print(f"Result   : ❌ FAILED (HTTP {resp.status})")
+                print(f"Error    : {error}: {description}")
+    except aiohttp.ClientConnectorError as exc:
+        print(f"Result   : ❌ CONNECTION ERROR — {exc}")
+
+
+async def main() -> None:
+    client_id = _require_env("OURA_CLIENT_ID")
+    client_secret = _require_env("OURA_CLIENT_SECRET")
+    refresh_token = _require_env("OURA_REFRESH_TOKEN")
+
+    print("Oura token endpoint probe")
+    print(f"client_id : {client_id[:8]}...{client_id[-4:]}")
+    print(f"refresh   : {refresh_token[:8]}...{refresh_token[-4:]}")
+
+    async with aiohttp.ClientSession() as session:
+        await try_refresh(session, LEGACY_ENDPOINT, client_id, client_secret, refresh_token)
+        await try_refresh(session, NEW_ENDPOINT, client_id, client_secret, refresh_token)
+
+    print(f"\n{'─' * 60}")
+    print(
+        "\nInterpretation:\n"
+        "  Legacy ✅ / New ❌ or ✅ → legacy-portal app, no action needed\n"
+        "  Legacy ❌ / New ✅      → new-portal app (#68), v2.8.6 fix applies\n"
+        "  Both   ❌               → credentials are wrong or tokens have expired"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_application_credentials.py
+++ b/tests/test_application_credentials.py
@@ -1,0 +1,116 @@
+"""Tests for the new-portal token endpoint fallback in application_credentials.py.
+
+Apps registered on developer.ouraring.com return 400 invalid_request when
+refreshing against the legacy api.ouraring.com/oauth/token endpoint.
+OuraOAuth2Implementation transparently retries against the new-portal endpoint
+on first rejection and updates token_url for all subsequent requests.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import RequestInfo
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
+
+from homeassistant.components.application_credentials import (
+    AuthorizationServer,
+    ClientCredential,
+)
+from homeassistant.helpers.config_entry_oauth2_flow import OAuth2TokenRequestReauthError
+
+from custom_components.oura.application_credentials import OuraOAuth2Implementation
+from custom_components.oura.const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN, OAUTH2_TOKEN_FALLBACK
+
+
+def _reauth_error(token_url: str = OAUTH2_TOKEN) -> OAuth2TokenRequestReauthError:
+    url = URL(token_url)
+    request_info = RequestInfo(url, "POST", CIMultiDictProxy(CIMultiDict()), url)
+    return OAuth2TokenRequestReauthError(
+        domain="oura", request_info=request_info, history=(), status=400
+    )
+
+
+def _make_impl() -> OuraOAuth2Implementation:
+    hass = MagicMock()
+    credential = ClientCredential(client_id="test_id", client_secret="test_secret")
+    auth_server = AuthorizationServer(
+        authorize_url=OAUTH2_AUTHORIZE,
+        token_url=OAUTH2_TOKEN,
+    )
+    return OuraOAuth2Implementation(hass, "oura.test_id", credential, auth_server)
+
+
+@pytest.mark.anyio
+async def test_legacy_success_no_fallback():
+    """Happy path: legacy endpoint works → token_url stays legacy."""
+    impl = _make_impl()
+    expected = {"access_token": "tok", "expires_in": 3600}
+
+    with patch.object(
+        impl.__class__.__bases__[0],
+        "_token_request",
+        new=AsyncMock(return_value=expected),
+    ) as mock_super:
+        result = await impl._token_request({"grant_type": "refresh_token"})
+
+    assert result == expected
+    assert impl.token_url == OAUTH2_TOKEN
+    mock_super.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_legacy_400_retries_fallback_and_succeeds():
+    """New-portal app: legacy 400 → retry against fallback → success, url updated."""
+    impl = _make_impl()
+    expected = {"access_token": "new_tok", "expires_in": 3600}
+    call_count = 0
+
+    async def _side_effect(self_inner, data):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise _reauth_error(OAUTH2_TOKEN)
+        return expected
+
+    with patch.object(impl.__class__.__bases__[0], "_token_request", new=_side_effect):
+        result = await impl._token_request({"grant_type": "refresh_token"})
+
+    assert result == expected
+    assert impl.token_url == OAUTH2_TOKEN_FALLBACK
+    assert call_count == 2
+
+
+@pytest.mark.anyio
+async def test_fallback_400_propagates_reauth_error():
+    """Both endpoints 400 → OAuth2TokenRequestReauthError propagates to coordinator."""
+    impl = _make_impl()
+    impl.token_url = OAUTH2_TOKEN_FALLBACK  # already on fallback
+
+    with patch.object(
+        impl.__class__.__bases__[0],
+        "_token_request",
+        new=AsyncMock(side_effect=_reauth_error(OAUTH2_TOKEN_FALLBACK)),
+    ):
+        with pytest.raises(OAuth2TokenRequestReauthError):
+            await impl._token_request({"grant_type": "refresh_token"})
+
+
+@pytest.mark.anyio
+async def test_already_on_fallback_succeeds_in_one_call():
+    """Once token_url is on the fallback endpoint, requests go through with a single call."""
+    impl = _make_impl()
+    impl.token_url = OAUTH2_TOKEN_FALLBACK  # simulates state after a previous switch
+    expected = {"access_token": "tok2", "expires_in": 3600}
+    call_count = 0
+
+    async def _side_effect(self_inner, data):
+        nonlocal call_count
+        call_count += 1
+        return expected
+
+    with patch.object(impl.__class__.__bases__[0], "_token_request", new=_side_effect):
+        result = await impl._token_request({"grant_type": "refresh_token"})
+
+    assert result == expected
+    assert call_count == 1  # no extra retry attempt
+    assert impl.token_url == OAUTH2_TOKEN_FALLBACK


### PR DESCRIPTION
## Summary

Apps registered on the new [developer.ouraring.com](https://developer.ouraring.com) portal fail every token refresh against the hardcoded legacy endpoint \https://api.ouraring.com/oauth/token\ with \400 invalid_request\. This is the root cause behind #61 and #54.

## Fix

Add \OuraOAuth2Implementation\ (subclass of HA's \AuthImplementation\) that intercepts token requests via \_token_request\:

1. **First attempt**: legacy endpoint \https://api.ouraring.com/oauth/token\ (unchanged for existing users)
2. **On \OAuth2TokenRequestReauthError\ (400–499)**: if not already on the new endpoint, log at DEBUG, switch \self.token_url\ to \https://moi.ouraring.com/oauth/v2/ext/oauth-token\, and retry once
3. **If fallback also 400s**: re-raise → coordinator converts to \ConfigEntryAuthFailed\ → HA reauth prompt (existing behaviour from v2.8.4)

Old-portal apps succeed on the first attempt; fallback never fires. No user action or re-registration required.

## Changes

- \const.py\: add \OAUTH2_TOKEN_FALLBACK\
- \pplication_credentials.py\: add \OuraOAuth2Implementation\ + \sync_get_auth_implementation\ (HA prefers this over \sync_get_authorization_server\ when present)
- \manifest.json\: bump to \2.8.6\
- \elease-notes.md\: prepend v2.8.6 entry
- \	ests/test_application_credentials.py\: 4 new tests covering all fallback paths

## Testing

✅ 123 tests passed (4 new)

Closes #68. Root cause of #61 / #54.